### PR TITLE
Changes to enable NPM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,10 @@
         },
         {
           "command": "extension.fabric8AnalyticsWidgetFullStack"
+        },
+        {
+          "command": "extension.fabric8AnalyticsWidget",
+          "when": "resourceFilename == package.json"
         }
       ]
     },

--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -7,7 +7,13 @@ export module  ProjectDataProvider {
     export let effectivef8PomWs: any;
     export let effectivef8Pom: any;
 
-    effectivef8PomWs = (item, cb) => {
+    effectivef8PomWs = (item, skip, cb) => {
+        // Directly call the callback if no effective POM generation is required,
+        // as is the case where there is no POM.
+        if (skip) {
+            cb(true);
+            return;
+        }
         let pomXmlFilePath: string = null;
         pomXmlFilePath = item.fsPath;
         const cmd: string = [
@@ -26,7 +32,7 @@ export module  ProjectDataProvider {
         });
     };
 
-    effectivef8Pom = (item,cb) => {
+    effectivef8Pom = (item, cb) => {
         let pomXmlFilePath: string = null;
         let filepath: string = 'target/pom.xml';
         pomXmlFilePath = item.fsPath;

--- a/src/multimanifestmodule.ts
+++ b/src/multimanifestmodule.ts
@@ -10,9 +10,9 @@ export module multimanifestmodule {
 
     export let find_manifests_workspace: any;
     export let form_manifests_payload: any;
-    export let find_epom_manifests_workspace: any;
+    export let find_epom_workspace: any;
 
-    find_epom_manifests_workspace = (context, provider, OSIO_ACCESS_TOKEN, cb) => {
+    find_epom_workspace = (context, provider, OSIO_ACCESS_TOKEN, cb) => {
 
         let payloadData : any;
         vscode.workspace.findFiles('{target/stackinfo/**/pom.xml,LICENSE}','**/node_modules').then(


### PR DESCRIPTION
The support was inbuilt for the most part from a single manifests'
analysis perspective, however the option to do the same did not show up
in the context menu in the editor window.

The other change required was when running analysis on the complete
workspace it always looked for a pom.xml in the root and did not proceed
if one was not found, changed that to include both pom.xml and
package.json.

Signed-off-by: Avishkar Gupta <avgupta@redhat.com>