### PR TITLE
fix(multi-ecosystem): if project has both package.json and pom.xml, c…

### DIFF
--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -154,7 +154,7 @@ export module  ProjectDataProvider {
             `--prefix="${manifestRootFolderPath}"`,
             '--depth=0',
             `-json >`,
-            `${manifestRootFolderPath}target/npmlist.json`
+            `"${manifestRootFolderPath}target/npmlist.json"`
         ].join(' ');
         console.log('npm list cmd '+ cmd);
         exec(cmd, (error: Error, _stdout: string, _stderr: string): void => {

--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -78,8 +78,12 @@ export module  ProjectDataProvider {
                 })
                 .catch(() => {
                     triggerNpmInstall(manifestRootFolderPath, (npmInstallResp) => {
-                        console.log('npm install Completed!!');
-                        effectivef8Package(item, cb);
+                        if(npmInstallResp) {
+                            console.log('npm install Completed!!');
+                            effectivef8Package(item, cb);
+                        } else {
+                            cb(false);
+                        }
                     });
                 });  
             }else {
@@ -182,7 +186,7 @@ export module  ProjectDataProvider {
                 // Do something
                 cb(true);
             } else {
-                vscode.window.showErrorMessage(`Failed to trigger npm install for ${manifestRootFolderPath}package.json`);
+                vscode.window.showErrorMessage(`Failed to trigger npm install for ${manifestRootFolderPath}package.json, ERR: ${_stderr}`);
                 console.log('_stderr'+ _stderr);
                 console.log('error'+ error);
                 cb(false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,8 +125,9 @@ export function activate(context: vscode.ExtensionContext) {
                     }
                   });
 
-                  if (!effective_pom_skip && pom_count !== result.length) {
+                  if (!effective_pom_skip && pom_count === 0) {
                     vscode.window.showInformationMessage('Multi ecosystem support is not yet available.');
+                    reject();
                     return;
                   }
                   if(effective_pom_skip) {

--- a/src/lspmodule.ts
+++ b/src/lspmodule.ts
@@ -27,7 +27,7 @@ export module lspmodule {
         // Options to control the language client
         let clientOptions: LanguageClientOptions = {
             // Register the server for plain text documents 'plaintext','xml','json'
-            documentSelector: ['*','xml','xsd'],
+            documentSelector: ['json','xml','xsd'],
                 synchronize: {
                     // Synchronize the setting section 'componentAnalysisServer' to the server
                     configurationSection: 'componentAnalysisServer',


### PR DESCRIPTION
### Stack analysis at Workspace

- If project has both package.json and pom.xml, consider maven project if pom.xml is found at root level.

- fixes issue with dir name having space or camelcase for npm


Tracks: 

- https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/154
- https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/153
- https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/151
- https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/150
- https://github.com/openshiftio/openshift.io/issues/4242