### PR TITLE
fix(command): updates two command to single to improve user experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.0.10 (November 2nd, 2018)
 * enhancement - add support for Quickfixes for any CVEs flagged with codeaction. See [#4516](https://github.com/openshiftio/openshift.io/issues/4516)
-* enhancement - add support to show progress along with Info toast when lsp calls comlete. See [#4487](https://github.com/openshiftio/openshift.io/issues/4487)
+* enhancement - provide one to command to trigger Dependency Analytics Report for a particular manifest/Application level. See [4518](https://github.com/openshiftio/openshift.io/issues/4518)
+* enhancement - add support to show progress along with Info toast when lsp calls complete.
 
 ## 0.0.9 (October 27th, 2018)
 * enhancement - add support to show progress when language Server is in action. See [#4487](https://github.com/openshiftio/openshift.io/issues/4487).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# How to contribute
+
+Contributions are essential for keeping this extension great.
+We try to keep it as easy as possible to contribute changes and we are
+open to suggestions for making it even easier.
+There are only a few guidelines that we need contributors to follow.
+
+## First Time Setup
+1. Install prerequisites:
+   * latest [Visual Studio Code](https://code.visualstudio.com/)
+   * [Node.js](https://nodejs.org/) v4.0.0 or higher
+2. Fork and clone the repository
+3. `cd fabric8-analytics-vscode-extension`
+4. Install the dependencies:
+
+	```bash
+	$ npm install
+	```
+5. Open the folder in VS Code
+
+## Run the extension locally
+
+1. Install `vsce` - A command line tool you'll use to publish extensions to the Extension Marketplace.
+    ```bash
+    $ npm install -g vsce
+    ```
+2. From root folder, run the below command.
+    ```bash
+    $ vsce package
+    ```
+3. `fabric8-analytics-<version>.vsix` file is created. Install it by following the instructions [here](https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix).
+
+> If you have any questions or run into any problems, please post an issue - we'll be very happy to help.

--- a/README.md
+++ b/README.md
@@ -1,87 +1,69 @@
 # Dependency Analytics
 
- Application stack analysis report with Insights about your application dependencies:
+[![Build Status](https://ci.centos.org/job/devtools-fabric8-analytics-vscode-extension/badge/icon)](https://ci.centos.org/job/devtools-fabric8-analytics-vscode-extension/)
+[![Chat](https://img.shields.io/badge/chat-on%20mattermost-brightgreen.svg)](https://chat.openshift.io/developers/channels/fabric8-analytics)
+[![Visual Studio Marketplace](https://vsmarketplacebadge.apphb.com/version/redhat.fabric8-analytics.svg)](https://marketplace.visualstudio.com/items?itemName=redhat.fabric8-analytics)
+
+ 'Dependency Analytics Report' with Insights about your application dependencies:
 - Flags a security vulnerability(CVE) and suggests a remedial version
 - Shows Github popularity metrics along with latest version
 - Suggests a project level license, check for conflicts between dependency licences
-- AI based guidance for alternative dependencies
-- AI based guidance for additional dependencies 
+- AI based guidance for additional, alternative dependencies
 
 ## Supported Languages
 
- 'Dependency Analytics' extension supports projects using Maven and projects build on npm (Node ecosystem). 
+'Dependency Analytics' extension supports projects using Maven and projects build on npm (Node ecosystem). 
 Extending support for Python and Go languages is currently under progress.
 
 ## Prerequisites
-* **For analyzing Java applications** Maven must be installed on your machine. Provide the Maven executable filepath.
-* **For analyzing Node applications** Node and npm must be installed on your machine. Provide the npm executable filepath.
 
-> **Note:** By default, the `mvn/npm` command is executed directly in the terminal, which requires that  `mvn/npm` is found in your system environment `PATH`.           
- If you do not want to add it into your system environment `PATH`, you can specify the maven executable path in settings. You can do this via preferences in VS Code:
+This extension assumes you have the following binaries on your `PATH`:
 
- File/Code > Preferences
-
-```
-{
-    ...
-    "maven.executable.path": "/path-to-maven-home/bin/mvn"
-    "npm.executable.path": "/path-to-npm-home/bin/npm"
-    ...
-}
-```
+* `mvn` (for analyzing Java applications)
+* `npm` (for analyzing Node applications)
 
 ## Quick Start
 
-1. Install the extension.
-
-2. How to use ?
-
-  - Open or edit a manifest file (`pom.xml` / `package.json`) to flag any CVEs present in your application
-  - Right click on a manifest file (`pom.xml`/`package.json`) in the 'Vscode File explorer' or  'Vscode File editor' to display 'Application stack analysis report' for your application.
+  - Install the extension.
+  - Opening or editing a manifest file (`pom.xml` / `package.json`) scans your application for security vulnerabilities.
+  - Right click on a manifest file (`pom.xml`/`package.json`) in the 'Vscode File explorer' or  'Vscode File editor' to display 'Dependency Analytics Report' for your application.
 
 
 ## Features
 
-Application stack analysis report with Insights about your application dependencies:
-- Flags a security vulnerability(CVE) and suggests a remedial version
-- Shows Github popularity metrics along with latest version
-- Suggests a project level license, check for conflicts between dependency licences
-- AI based guidance for alternative dependencies
-- AI based guidance for additional dependencies 
-
-![ screencast ](https://raw.githubusercontent.com/fabric8-analytics/fabric8-analytics-vscode-extension/master/images/stackanalysis.gif)
-
-Alerts for any CVEs are shown in the **PROBLEMS** tab when you open the `pom.xml / package.json` manifest file.
+- Opening or editing a manifest file (`pom.xml` / `package.json`) scans your application for security vulnerabilities, flag them along with 'quick fixes'.
 
 ![ screencast ](https://raw.githubusercontent.com/fabric8-analytics/fabric8-analytics-vscode-extension/master/images/compAnalysis.png)
 
+- Right click on a manifest file(`pom.xml` / `package.json`) and choose 'Dependency Analytics Report ...' to display 'Dependency Analytics' report. This report covers deeper insights into your application dependencies:
+1. Flags a security vulnerability(CVE) and suggests a remedial version
+2. Shows Github popularity metrics along with latest version
+3. Suggests a project level license, check for conflicts between dependency licences
+4. AI based guidance for additional,alternative dependencies
 
-## Usage
+![ screencast ](https://raw.githubusercontent.com/fabric8-analytics/fabric8-analytics-vscode-extension/master/images/stackanalysis.gif)
 
-You can get 'Application stack analysis report' with Insights (Security, License and guidance for additional/alternative) about your application dependencies
+- **For multi module maven application** Right click on root `pom.xml` in editor window and choose 'Dependency Analytics Report ...' to display 'Dependency Analytics' report for the entire application.
 
-To view the 'Application's stack analysis report' for a specific module:
-1. Open a manifest file (`pom.xml`, `package.json`).
-2. Use `Ctrl+Shift+P` on Linux or `Cmd+Shift+P` on Mac, and then click **Generate application stack report on manifest file** to see the application's stack analysis report for the manifest file.
+![ screencast ](https://raw.githubusercontent.com/fabric8-analytics/fabric8-analytics-vscode-extension/master/images/stackanalysis.gif)
+
+-------------------------------------------------------------------------------------------------------------------
+**Note** It creates a folder `target` in workspace which is used for processing of manifest files, needed for generating stack report. So kindly add `target` in `.gitignore`.
+
+Know more about Dependency Analytics Platform
+==============================================
+The mission of this project is to significantly enhance developer experience:
+providing Insights(security, licenses, AI based guidance) for applications and helping developers, Enterprises.
+
+- [GitHub Organisation](https://github.com/fabric8-analytics)
+
+Feedback & Questions
+====================
+* File a bug in [GitHub Issues](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues)
+* Chat with us on [Mattermost](https://chat.openshift.io/developers/channels/fabric8-analytics)
+
+License
+=======
+Apache 2.0, See [LICENSE](LICENSE) for more information.
 
 
-To view the 'Application's stack analysis report' for the entire project (including multiple sub-modules):
-* Use command `Ctrl+Shift+P` on Linux or `Cmd+Shift+P` on Mac, and then click **Generate application stack report on Workspace** to view the application's stack analysis report for the entire workspace/project.
-
-## Contributing
-
-This is an open source project, contributions and questions are welcome. If you have any feedback, suggestions, or ideas, reach us on:
-* Chat: [#openshiftio  ](https://chat.openshift.io/developers/channels/town-square).
-* Log issues:  [GitHub Repository](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues).
-
-## Note
-
-It creates a folder `target` in workspace which is used for processing of manifest files, needed for generating stack report. So kindly add `target` in `.gitignore`.
-
-### Develop this extension
-
-1. Install the dependencies:
-`npm install`.
-2. Start the compiler in watch mode:
-`npm run compile`.
-3. Open this folder in VS Code and press `F5`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fabric8-analytics",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -882,9 +882,9 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fabric8-analytics-lsp-server": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.1.44.tgz",
-      "integrity": "sha512-kk3K/vYG6Bi8blz+gvsWMHh1S9ae5INCILs8kCA/7BcEOZR9MB2k8afOElTYuIgLbXtqoMS/danEub7TOEI/PQ==",
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.1.46.tgz",
+      "integrity": "sha512-zNHpLhMI6IKkBfR+SAc6Uun7qAXx+XJRv/lZKu6Et1dFQqoNmE+kL7IZY+nyWo8OhTtizZwPJRIBCdUjzDqp3A==",
       "requires": {
         "request": "^2.79.0",
         "stream-json": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fabric8-analytics",
   "displayName": "Dependency Analytics",
   "description": "Insights about your application dependencies: Security, License compatibility and AI based guidance to choose appropriate dependencies for your application.",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": "Red Hat",
   "publisher": "redhat",
   "preview": true,
@@ -13,10 +13,6 @@
     }
   ],
   "license": "Apache-2.0",
-  "galleryBanner": {
-    "color": "#000000",
-    "theme": "dark"
-  },
   "bugs": {
     "url": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues",
     "email": "jakumar@redhat.com"
@@ -27,15 +23,14 @@
   },
   "homepage": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/blob/master/README.md",
   "categories": [
-    "Programming Languages",
     "Other"
   ],
   "keywords": [
-    "Dependencies",
-    "Vulnerabilities",
-    "License",
-    "Node",
-    "Maven"
+    "dependencies",
+    "vulnerability",
+    "license",
+    "node",
+    "java"
   ],
   "icon": "icon/openshift_logo.png",
   "engines": {
@@ -43,50 +38,41 @@
   },
   "activationEvents": [
     "onCommand:extension.fabric8AnalyticsWidgetFullStack",
-    "onLanguage:xml",
-    "onLanguage:json"
+    "workspaceContains:**/package.json",
+    "workspaceContains:**/pom.xml"
   ],
   "main": "./out/src/extension",
   "contributes": {
     "languages": [
       {
-        "id": "Security",
+        "id": "security",
         "aliases": [
-          "CVE"
-        ]
-      },
-      {
-        "id": "application-license",
-        "aliases": [
-          "license-conflict"
-        ]
-      },
-      {
-        "id": "Insights",
-        "aliases": [
-          "Artificial-Intelligence",
-          "Deep-Learning",
-          "Machine-Learning",
-          "Analytics",
-          "suggest-dependencies"
-        ]
-      },
-      {
-        "id": "Opensource",
-        "aliases": [
-          "maven",
-          "java",
-          "npm",
+          "CVE",
           "pom.xml",
           "package.json"
+        ]
+      },
+      {
+        "id": "analytics",
+        "aliases": [
+          "AI",
+          "artificial intelligence",
+          "deep learning",
+          "suggest dependencies"
         ]
       }
     ],
     "commands": [
       {
-        "key": "ctrl+k",
         "command": "extension.fabric8AnalyticsWidgetFullStack",
-        "title": "View Dependency Analytics Report ..."
+        "title": "Dependency Analytics Report ..."
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "extension.fabric8AnalyticsWidgetFullStack",
+        "key": "ctrl+d",
+        "mac": "cmd+d"
       }
     ],
     "menus": {
@@ -109,7 +95,7 @@
           "command": "extension.fabric8AnalyticsWidgetFullStack",
           "when": "resourceFilename == pom.xml"
         }
-      ], 
+      ],
       "editor/context": [
         {
           "command": "extension.fabric8AnalyticsWidgetFullStack",
@@ -181,7 +167,7 @@
     "remap-istanbul": "^0.12.0"
   },
   "dependencies": {
-    "fabric8-analytics-lsp-server": "0.1.44",
+    "fabric8-analytics-lsp-server": "0.1.46",
     "fs": "0.0.1-security",
     "path": "^0.12.7",
     "request": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "vscode": "^1.23.0"
   },
   "activationEvents": [
-    "onCommand:extension.fabric8AnalyticsWidget",
     "onCommand:extension.fabric8AnalyticsWidgetFullStack",
     "onLanguage:xml",
     "onLanguage:json"
@@ -85,42 +84,40 @@
     ],
     "commands": [
       {
-        "key": "ctrl+j",
-        "command": "extension.fabric8AnalyticsWidget",
-        "title": "Generate application stack report on manifest file"
-      },
-      {
         "key": "ctrl+k",
         "command": "extension.fabric8AnalyticsWidgetFullStack",
-        "title": "Generate application stack report on Workspace"
+        "title": "View Dependency Analytics Report ..."
       }
     ],
     "menus": {
       "editor/title": [
         {
-          "command": "extension.fabric8AnalyticsWidget",
+          "command": "extension.fabric8AnalyticsWidgetFullStack",
           "when": "resourceLangId == xml"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStack"
+          "command": "extension.fabric8AnalyticsWidgetFullStack",
+          "when": "resourceLangId == json"
         }
       ],
       "explorer/context": [
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStack"
+          "command": "extension.fabric8AnalyticsWidgetFullStack",
+          "when": "resourceFilename == package.json"
+        },
+        {
+          "command": "extension.fabric8AnalyticsWidgetFullStack",
+          "when": "resourceFilename == pom.xml"
         }
-      ],
+      ], 
       "editor/context": [
         {
-          "command": "extension.fabric8AnalyticsWidget",
-          "when": "resourceLangId == xml"
-        },
-        {
-          "command": "extension.fabric8AnalyticsWidgetFullStack"
-        },
-        {
-          "command": "extension.fabric8AnalyticsWidget",
+          "command": "extension.fabric8AnalyticsWidgetFullStack",
           "when": "resourceFilename == package.json"
+        },
+        {
+          "command": "extension.fabric8AnalyticsWidgetFullStack",
+          "when": "resourceFilename == pom.xml"
         }
       ]
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,7 +7,6 @@ export namespace Commands {
     /**
      * Triggers Stack Analysis
      */
-    export const TRIGGER_STACK_ANALYSIS = 'extension.fabric8AnalyticsWidget';
     export const TRIGGER_FULL_STACK_ANALYSIS = 'extension.fabric8AnalyticsWidgetFullStack';
     export const TRIGGER_LSP_EDIT = 'lsp.applyTextEdit';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,9 +21,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	let provider = new contentprovidermodule.TextDocumentContentProvider();  //new TextDocumentContentProvider();
 	let registration = vscode.workspace.registerTextDocumentContentProvider('fabric8-analytics-widget', provider);
-
-	let disposable = vscode.commands.registerCommand(Commands.TRIGGER_STACK_ANALYSIS, () => stackanalysismodule.triggerStackAnalyses(context, provider, previewUri));
-	let disposableFullStack = vscode.commands.registerCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS, () => multimanifestmodule.triggerFullStackAnalyses(context, provider, previewUri));
+	
+	let disposableFullStack = vscode.commands.registerCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS, () => multimanifestmodule.dependencyAnalyticsReportFlow(context, provider, previewUri));
 	
 	let runCodeAction = ((document: vscode.TextDocument, range: vscode.Range, message:string) => {
 		let edit = new vscode.WorkspaceEdit();
@@ -92,13 +91,13 @@ export function activate(context: vscode.ExtensionContext) {
 			});
 
 
-			context.subscriptions.push(disposable, registration,lspClient.start(), disposableFullStack, disposableLspEdit);
+			context.subscriptions.push(registration,lspClient.start(), disposableFullStack, disposableLspEdit);
 		}
 	});
 
 	let showInfoOnfileOpen = ((msg: string) => {
-		vscode.window.showInformationMessage(`${msg}.`, 'View detailed report').then((selection:any) => {
-			if(selection === 'View detailed report'){
+		vscode.window.showInformationMessage(`${msg}.`, 'View Dependency Analytics Report ...').then((selection:any) => {
+			if(selection === 'View Dependency Analytics Report ...'){
 				vscode.commands.executeCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS);
 			}
 		});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 
 import { Commands } from './commands';
 import { contentprovidermodule } from './contentprovidermodule';
-import { stackanalysismodule } from './stackanalysismodule';
 import { multimanifestmodule } from './multimanifestmodule';
 import { authextension } from './authextension';
 import { StatusMessages } from './statusMessages';
@@ -77,8 +76,8 @@ export function activate(context: vscode.ExtensionContext) {
 				lspClient.onNotification('caNotification', (respData) => {
 					vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: StatusMessages.EXT_TITLE}, p => {
 						return new Promise((resolve, reject) => {
-							p.report({message: '[Dependency Analytics] Checking for security vulnerabilities ...' });
-							p.report({message: '[Dependency Analytics] '+respData.data });
+							p.report({message: 'Checking for security vulnerabilities ...' });
+							p.report({message: respData.data });
 							setTimeout(function () {	
 							  resolve();
 							  if(respData && respData.hasOwnProperty('isEditAction') && !respData.isEditAction) {
@@ -96,8 +95,8 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	let showInfoOnfileOpen = ((msg: string) => {
-		vscode.window.showInformationMessage(`${msg}.`, 'View Dependency Analytics Report ...').then((selection:any) => {
-			if(selection === 'View Dependency Analytics Report ...'){
+		vscode.window.showInformationMessage(`${msg}.`, 'Dependency Analytics Report ...').then((selection:any) => {
+			if(selection === 'Dependency Analytics Report ...'){
 				vscode.commands.executeCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS);
 			}
 		});

--- a/src/multimanifestmodule.ts
+++ b/src/multimanifestmodule.ts
@@ -186,76 +186,76 @@ export module multimanifestmodule {
     };
 
     triggerFullStackAnalyses = (context, provider, previewUri) => {
-            provider.signalInit(previewUri,null);
-            vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: StatusMessages.EXT_TITLE}, p => {
-                return new Promise((resolve, reject) => { 
-                
-                vscode.workspace.findFiles('{pom.xml,**/package.json}','**/node_modules').then(
-                  (result: vscode.Uri[]) => {
-                      if(result && result.length){
-                        // Do not create an effective pom if no pom.xml is present
-                        let effective_pom_skip = true;
-                        let effectiveF8WsVar = 'effectivef8Package';
-                        let vscodeRootpath = vscode.workspace.rootPath;
-                        if(process && process.platform && process.platform.toLowerCase() === 'win32'){
-                            vscodeRootpath += '\\';
-                        } else {
-                            vscodeRootpath += '/'; 
+        provider.signalInit(previewUri,null);
+        vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: StatusMessages.EXT_TITLE}, p => {
+            return new Promise((resolve, reject) => { 
+            
+            vscode.workspace.findFiles('{pom.xml,**/package.json}','**/node_modules').then(
+                (result: vscode.Uri[]) => {
+                    if(result && result.length){
+                    // Do not create an effective pom if no pom.xml is present
+                    let effective_pom_skip = true;
+                    let effectiveF8WsVar = 'effectivef8Package';
+                    let vscodeRootpath = vscode.workspace.rootPath;
+                    if(process && process.platform && process.platform.toLowerCase() === 'win32'){
+                        vscodeRootpath += '\\';
+                    } else {
+                        vscodeRootpath += '/'; 
+                    }
+                    let filesRegex = 'target/package.json';
+                    let pom_count = 0;
+                    result.forEach((item) => {
+                        if (item.fsPath.indexOf('pom.xml') >= 0) {
+                        effective_pom_skip = false;
+                        pom_count += 1;
+                        effectiveF8WsVar = 'effectivef8PomWs';
+                        filesRegex = 'target/stackinfo/**/pom.xml';
                         }
-                        let filesRegex = 'target/package.json';
-                        let pom_count = 0;
-                        result.forEach((item) => {
-                          if (item.fsPath.indexOf('pom.xml') >= 0) {
-                            effective_pom_skip = false;
-                            pom_count += 1;
-                            effectiveF8WsVar = 'effectivef8PomWs';
-                            filesRegex = 'target/stackinfo/**/pom.xml';
-                          }
-                        });
-      
-                        if (!effective_pom_skip && pom_count === 0) {
-                          vscode.window.showInformationMessage('Multi ecosystem support is not yet available.');
-                          reject();
-                          return;
-                        } 
-                        else {
-                            p.report({message: StatusMessages.WIN_RESOLVING_DEPENDENCIES});
-                            ProjectDataProvider[effectiveF8WsVar](vscodeRootpath, (dataEpom) => {
-                                if(dataEpom){
-                                  p.report({message: StatusMessages.WIN_ANALYZING_DEPENDENCIES});
-                                  let promiseTriggerManifestWs = triggerManifestWs(context, filesRegex, provider, previewUri);
-                                  promiseTriggerManifestWs.then(() => {
-                                    p.report({message: StatusMessages.WIN_SUCCESS_ANALYZE_DEPENDENCIES});
-                                    resolve();
-                                  })
-                                  .catch(() => {
-                                    p.report({message: StatusMessages.WIN_FAILURE_ANALYZE_DEPENDENCIES});
-                                    reject();
-                                  }); 
-                                } else {
-                                  p.report({message: StatusMessages.WIN_FAILURE_ANALYZE_DEPENDENCIES});
-                                  reject();
-                                }
-                            });
-                        }
-                      } else {
-                        vscode.window.showInformationMessage(`Coudn't find manifest at root workspace level`);
+                    });
+    
+                    if (!effective_pom_skip && pom_count === 0) {
+                        vscode.window.showInformationMessage('Multi ecosystem support is not yet available.');
                         reject();
-                      }
-                  },
-                  // Other ecosystem flow
-                  (reason: any) => {
-                    vscode.window.showInformationMessage(`Coudn't find supported manifest at root workspace level`);
-                  });
-              });
+                        return;
+                    } 
+                    else {
+                        p.report({message: StatusMessages.WIN_RESOLVING_DEPENDENCIES});
+                        ProjectDataProvider[effectiveF8WsVar](vscodeRootpath, (dataEpom) => {
+                            if(dataEpom){
+                                p.report({message: StatusMessages.WIN_ANALYZING_DEPENDENCIES});
+                                let promiseTriggerManifestWs = triggerManifestWs(context, filesRegex, provider, previewUri);
+                                promiseTriggerManifestWs.then(() => {
+                                p.report({message: StatusMessages.WIN_SUCCESS_ANALYZE_DEPENDENCIES});
+                                resolve();
+                                })
+                                .catch(() => {
+                                p.report({message: StatusMessages.WIN_FAILURE_ANALYZE_DEPENDENCIES});
+                                reject();
+                                }); 
+                            } else {
+                                p.report({message: StatusMessages.WIN_FAILURE_ANALYZE_DEPENDENCIES});
+                                reject();
+                            }
+                        });
+                    }
+                    } else {
+                    vscode.window.showInformationMessage(`Coudn't find manifest at root workspace level`);
+                    reject();
+                    }
+                },
+                // Other ecosystem flow
+                (reason: any) => {
+                vscode.window.showInformationMessage(`Coudn't find supported manifest at root workspace level`);
+                });
             });
+        });
     };
 
     triggerManifestWs = (context, filesRegex, provider, previewUri) => {
         return new Promise((resolve,reject) => {
             authextension.authorize_f8_analytics(context, (data) => {
             if(data){
-                vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.One, 'Application stack report').then((success) => {
+                vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.One, StatusMessages.REPORT_TAB_TITLE).then((success) => {
                     let manifest_finder = multimanifestmodule.find_manifests_workspace;
                     manifest_finder(context, filesRegex, (data) => {
                         if(data){

--- a/src/stackanalysismodule.ts
+++ b/src/stackanalysismodule.ts
@@ -51,10 +51,7 @@ export module stackanalysismodule {
             if(process && process.platform && process.platform.toLowerCase() === 'win32'){
                 strSplit = '\\';
             }
-            let projRootPathSplit: any = encodedProjRootPath.split(strSplit);
-            let projName: string = projRootPathSplit[projRootPathSplit.length-1];
-            let filePathList = file_uri.split(projName+strSplit);
-            
+            let filePathList = file_uri.split(encodedProjRootPath+strSplit);
             if(filePathList && filePathList.length>1) {
             vscode.workspace.findFiles(`{${filePathList[1]},LICENSE}`,null).then(
                 (result: vscode.Uri[]) => {
@@ -125,7 +122,7 @@ export module stackanalysismodule {
                         provider.signalInit(previewUri,null);
                         authextension.authorize_f8_analytics(context, (data) => {
                             if(data){
-                              return vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.One, 'Application stack report').then((success) => {
+                              return vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.One, StatusMessages.REPORT_TAB_TITLE).then((success) => {
                                 stackanalysismodule.get_stack_metadata(context, dataEpom, (data) => {
                                   if(data){
                                     p.report({message: StatusMessages.WIN_SUCCESS_ANALYZE_DEPENDENCIES });

--- a/src/stackanalysismodule.ts
+++ b/src/stackanalysismodule.ts
@@ -16,7 +16,6 @@ export module stackanalysismodule {
     export let stack_collector: any;
     export let get_stack_metadata: any;
     export let post_stack_analysis: any;
-    export let triggerStackAnalyses: any;
     export let processStackAnalyses: any;
 
     stack_collector = (file_uri, id, cb) => {
@@ -158,15 +157,5 @@ export module stackanalysismodule {
         }
     };
 
-    triggerStackAnalyses = (context, provider, previewUri) => {
-        if(vscode.workspace.hasOwnProperty('workspaceFolders') && vscode.workspace.hasOwnProperty['workspaceFolders'] &&
-        vscode.workspace['workspaceFolders'] && vscode.workspace['workspaceFolders'].length>1){
-            vscode.window.showInformationMessage('Multi-root Workspaces are not supported currently');
-        } else if(vscode.window.activeTextEditor){
-            processStackAnalyses(context, provider, previewUri);
-        } else {
-            vscode.window.showInformationMessage('No manifest file is active in editor');
-        }
-    };
 
 }

--- a/src/statusMessages.ts
+++ b/src/statusMessages.ts
@@ -5,10 +5,11 @@
  */
 export namespace StatusMessages {
     export const EXT_TITLE = 'Dependency Analytics';
-    export const WIN_RESOLVING_DEPENDENCIES = '[Dependency Analytics] Resolving application dependencies...';
-    export const WIN_ANALYZING_DEPENDENCIES = '[Dependency Analytics] Analyzing application dependencies...';
+    export const WIN_RESOLVING_DEPENDENCIES = 'Resolving application dependencies...';
+    export const WIN_ANALYZING_DEPENDENCIES = 'Analyzing application dependencies...';
     export const WIN_SUCCESS_ANALYZE_DEPENDENCIES = 'Successfully generated stack report';
     export const WIN_FAILURE_ANALYZE_DEPENDENCIES = 'Unable to generate stack report';
     export const WIN_FAILURE_RESOLVE_DEPENDENCIES = 'Unable to generate stack report';
     export const LSP_INITIALIZE = 'Initializing Language Server';
+    export const REPORT_TAB_TITLE = 'Dependency Analytics Report';
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -250,7 +250,7 @@ export namespace Templates {
         <div id="loading_screen">
         <div style="text-align: center;margin-top:130px;" id="caption">
             <h1 style='color:#ffffff'>Dependency Analytics</h1>
-            <h1 style='color:#ffffff'>Application stack analysis in progress</h1>
+            <h2 style='color:#ffffff'>Analyzing application dependencies...</h2>
             <br />
             <br />
             <br />

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -20,7 +20,6 @@ suite('Fabric8 Analytics Extension', () => {
 		return vscode.commands.getCommands(true).then((commands) =>
 		{
 			const FABRIC8_COMMANDS:string[] = [
-				Commands.TRIGGER_STACK_ANALYSIS,
 				Commands.TRIGGER_FULL_STACK_ANALYSIS
 			];
 			let foundFabric8Commands = commands.filter(function(value){
@@ -30,15 +29,6 @@ suite('Fabric8 Analytics Extension', () => {
 		});
 	}); 
 
-	
-	test('should trigger application stack report activate', async () => {
-		await vscode.commands.executeCommand(Commands.TRIGGER_STACK_ANALYSIS).then((res) => {
-			assert.ok(true);
-		},(reason: any) => {
-			assert.equal(reason.name, 'Error');
-			assert.equal(reason.message, `Running the contributed command:'extension.fabric8AnalyticsWidget' failed.`)
-		});
-	});
 
 	test('should trigger fabric8-analytics full stack report activate', async () => {
 		await vscode.commands.executeCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS).then((res) => {

--- a/test/stackanalysismodule.test.ts
+++ b/test/stackanalysismodule.test.ts
@@ -107,11 +107,6 @@ suite('stacknalysis module', () => {
 
     suite('stacknalysis module: no manifest opened', () => {
 
-        test('triggerStackAnalyses should show info message as no manifest opened in editor', () => {
-            let showInfoMessageSpy = sandbox.spy(vscode.window, 'showInformationMessage');
-            stackanalysismodule.triggerStackAnalyses(context, provider, previewUri);
-            expect(showInfoMessageSpy).calledOnce;
-        });
     
         test('processStackAnalyses should not call effectivef8Package', () => {
             let effectivef8PackageSpy = sandbox.spy(ProjectDataProvider, 'effectivef8Package');
@@ -179,11 +174,6 @@ suite('stacknalysis module', () => {
             expect(stubExecuteCommand).callCount(0);
         });
 
-        test('triggerStackAnalyses should call processStackAnalyses as manifest file is opened in editor', () => {
-            let stubProcessStackAnalyses = sandbox.stub(stackanalysismodule, 'processStackAnalyses');
-            stackanalysismodule.triggerStackAnalyses(context, provider, previewUri);
-            expect(stubProcessStackAnalyses).calledOnce;
-        });
 
         test('get_stack_metadata should call vscode API findFiles, postStackAnalysisService, form_manifests_payload as manifest file is opened in editor', async () => {
             let rootPath = vscode.workspace.rootPath;


### PR DESCRIPTION
Currently, there two separate commands to trigger stack analyses
- Generate Stack Analyses on Manifest
- Generate Stack Analyses on Workspace


With this change, user will have just one command
- View Dependency Analytics Report ... 
It'll handle both workspace and manifest flow depending on the context from it's being triggered.

### Tracks: 
- https://github.com/openshiftio/openshift.io/issues/4518