### PR TITLE
fix(transitive): Enable transitive dependency report by default

### DIFF
--- a/src/stackanalysismodule.ts
+++ b/src/stackanalysismodule.ts
@@ -48,6 +48,7 @@ export module stackanalysismodule {
               }stack-analyses/?user_key=${Apiendpoint.STACK_API_USER_KEY}`;
               options['formData'] = payloadData;
               options['headers'] = {
+                showTransitiveReport: 'true',
                 origin: 'vscode',
                 ecosystem: Apiendpoint.API_ECOSYSTEM
               };


### PR DESCRIPTION
Currently transitive report is enabled only for PyPi, it should be enabled by default for other ecosystems(npm and maven) as well. We can back-out this changeset once it is enabled by default from platform.