### PR TITLE
feat(welcome-msg): Show welcome message after upgrading to latest version

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,14 @@
+'use strict';
+
+/**
+ * Commonly used constants
+ */
+export enum GlobalState {
+  // to store the current version string to localStorage
+  Version = 'fabric8Version'
+}
+
+// Refer `name` from package.json
+export const extensionId = 'fabric8-analytics';
+// publisher.name from package.json
+export const extensionQualifiedId = `redhat.${extensionId}`;


### PR DESCRIPTION
Dependency Analytics version is retrieved from `package.json` and stored in `[globalState](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext.globalState)`. Whenever a new version is updated and loaded into vscode, previous version will be retrieved from `globalState` and compared with current version to show the message.

This PR fixes #311.

Look at the notification from right bottom side of the below screenshot,
<img width="1552" alt="Screen Shot 2019-08-26 at 4 33 30 PM" src="https://user-images.githubusercontent.com/3874763/63686338-48a7ab00-c81f-11e9-8bfe-1a6724f00fe5.png">
