### PR TITLE
fix(timeout): Fix stack report polling frequency and duration

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,3 +12,7 @@ export enum GlobalState {
 export const extensionId = 'fabric8-analytics';
 // publisher.name from package.json
 export const extensionQualifiedId = `redhat.${extensionId}`;
+// GET request timeout
+export const getRequestTimeout = 20 * 1000; // ms
+// GET request polling frequency
+export const getRequestPollInterval = 2 * 1000; // ms

--- a/src/stackAnalysisService.ts
+++ b/src/stackAnalysisService.ts
@@ -92,6 +92,11 @@ export module stackAnalysisServices {
               httpResponse.statusCode
             } - ${httpResponse.statusMessage} `;
             reject(errorMsg);
+          } else if (httpResponse.statusCode === 408) {
+            errorMsg = `Stack analysis request has timed out. Status:  ${
+              httpResponse.statusCode
+            } - ${httpResponse.statusMessage} `;
+            reject(errorMsg);
           } else {
             clearContextInfo(context);
             errorMsg = `Failed to trigger application's stack analysis, try in a while. Status: ${


### PR DESCRIPTION
This PR fixes VSIX side of issue #304. Also it handles new HTTP error code which got introduced part of https://github.com/fabric8-analytics/fabric8-analytics-server/pull/576.

Polling duration is 20s, polling frequency 2s. 