### PR TITLE
fix(pypi): Install pip packages on user site

### DIFF
--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -288,7 +288,6 @@ export module ProjectDataProvider {
         pyPiInterpreter,
         `-m pip install`,
         `--user`,
-        `--ignore-installed`,
         `-r`,
         reqTxtFilePath,
         `&&`,


### PR DESCRIPTION
This fix adds a switch to `pip install`.
`--user` - To install dependencies on user's local site directory