### PR TITLE
chore: Update fabric8-analytics-lsp-server version to 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -735,9 +735,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fabric8-analytics-lsp-server": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.2.1.tgz",
-      "integrity": "sha512-+eq1fk/Mszsk6NgKYKPTD/lLgDbF1/NPLdpninLk/T6BzyiS/wilJZaVAXkZuYw0k0tZtQ9OXlSRXWLYv1QA1Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.2.2.tgz",
+      "integrity": "sha512-eOWIg8fI/dV+0wGzFa3R2Hxc7VW7na6qMXou3RHMrWzzNZ/dOpWSCAIr0jWlgCz33WBqby70ykNhjkxocnypHw==",
       "requires": {
         "request": "^2.79.0",
         "stream-json": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
-    "fabric8-analytics-lsp-server": "0.2.1",
+    "fabric8-analytics-lsp-server": "0.2.2",
     "fs": "0.0.1-security",
     "path": "0.12.7",
     "request": "2.88.0",


### PR DESCRIPTION
Update to latest fabric8-analytics-lsp-server to 0.2.2