### PR TITLE
chore: Update fabric8-analytics-lsp-server version to 0.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -735,11 +735,11 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fabric8-analytics-lsp-server": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.2.2.tgz",
-      "integrity": "sha512-eOWIg8fI/dV+0wGzFa3R2Hxc7VW7na6qMXou3RHMrWzzNZ/dOpWSCAIr0jWlgCz33WBqby70ykNhjkxocnypHw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.2.8.tgz",
+      "integrity": "sha512-3AYH4Uo+N7D1dGbVYJeQU32hAphO4zekLmZGms0rFV6gQrrgR+gjqcigYNIfMtULlYLttrZsLo8nWXNBE7eaUw==",
       "requires": {
-        "request": "^2.79.0",
+        "node-fetch": "^2.6.0",
         "stream-json": "0.6.1",
         "vscode-languageserver": "^5.3.0-next.9",
         "winston": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
-    "fabric8-analytics-lsp-server": "0.2.2",
+    "fabric8-analytics-lsp-server": "0.2.8",
     "fs": "0.0.1-security",
     "node-fetch": "^2.6.0",
     "path": "0.12.7",


### PR DESCRIPTION
https://github.com/fabric8-analytics/fabric8-analytics-lsp-server/releases/tag/v0.2.8 

https://www.npmjs.com/package/fabric8-analytics-lsp-server/v/0.2.8 