### PR TITLE
fix: Rename notification button with 'Click here for Detailed Vulnerability Report'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,7 +152,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   let showInfoOnfileOpen = (msg: string) => {
     vscode.window
-      .showInformationMessage(`${msg}. Powered by [Snyk](${registrationURL})`, 'Dependency Analytics Report ...')
+      .showInformationMessage(`${msg}. Powered by [Snyk](${registrationURL})`, 'Click here for Detailed Vulnerability Report')
       .then((selection: any) => {
         if (selection === 'Dependency Analytics Report ...') {
           vscode.commands.executeCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS);


### PR DESCRIPTION
Rename notification button with `'Click here for Detailed Vulnerability Report'`
![Screenshot from 2020-10-06 00-30-07](https://user-images.githubusercontent.com/42376860/95120433-2ba41200-076b-11eb-98da-411d4aa8b3d1.png)
