### PR TITLE
fix: Propagate errors from lsp server to client

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,6 +141,7 @@ export function activate(context: vscode.ExtensionContext) {
             );
           }
         });
+
         lspClient.onNotification('caError', respData => {
           if (
             respData &&

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,6 +141,16 @@ export function activate(context: vscode.ExtensionContext) {
             );
           }
         });
+        lspClient.onNotification('caError', respData => {
+          if (
+            respData &&
+            respData.hasOwnProperty('data') &&
+            vscode.window.activeTextEditor
+          ) {
+            onFileOpen.push(vscode.window.activeTextEditor.document.fileName);
+            showErrorOnfileOpen(respData.data);
+          }
+        });
       });
       context.subscriptions.push(
         lspClient.start(),
@@ -158,6 +168,10 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.commands.executeCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS);
         }
       });
+  };
+
+  let showErrorOnfileOpen = (msg: string) => {
+    vscode.window.showErrorMessage(`${msg}. Powered by [Snyk](${registrationURL})`)
   };
 }
 


### PR DESCRIPTION
As part of Golang CA implementation on LSP, we need an option to notify LSP client about parsing / manifest file errors. This PR is to support such generic error propagation from LSP server to LSP client.

Jira TIcket :: https://issues.redhat.com/browse/APPAI-1524