### PR TITLE
fix: [APPAI-1636] Propagating go binary path to LSP

### DIFF
--- a/src/authextension.ts
+++ b/src/authextension.ts
@@ -4,6 +4,7 @@ import { Apiendpoint } from './apiendpoint';
 import { stackAnalysisServices } from './stackAnalysisService';
 import { GlobalState } from './constants';
 import fetch from 'node-fetch'
+import { Utils } from './Utils';
 
 export module authextension {
   export let setContextData: any;
@@ -16,6 +17,7 @@ export module authextension {
       context_f8_access_routes.prod + '/api/v2';
     process.env['THREE_SCALE_USER_TOKEN'] = context_f8_3scale_user_key;
     process.env['PROVIDE_FULLSTACK_ACTION'] = 'true';
+    process.env['GOLANG_EXECUTABLE'] = Utils.getGoExecutable();
   };
 
   export function setUUID(uuid) {


### PR DESCRIPTION
Need to propagate go executable (binary) path to LSP server in order to trigger golang CA.
fixes jira ticket :: https://issues.redhat.com/browse/APPAI-1636