### PR TITLE
chore: Change UPLOAD_LOCATION to align with other RH extensions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node('rhel7'){
 
 	stage 'Upload fabric8-analytics-vscode-extension to staging'
 	def vsix = findFiles(glob: '**.vsix')
-	sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/stable/vscode-analytics/"
+	sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/stable/vscode-dependency-analytics/"
 	stash name:'vsix', includes:vsix[0].path
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node('rhel7'){
 
 	stage 'Upload fabric8-analytics-vscode-extension to staging'
 	def vsix = findFiles(glob: '**.vsix')
-	sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}"
+	sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/stable/vscode-analytics/"
 	stash name:'vsix', includes:vsix[0].path
 }
 


### PR DESCRIPTION
Use the umbrella vscode directory similar to other RedHat VSCode extensions.

Example: https://github.com/redhat-developer/vscode-openshift-extension-pack/blob/master/openshift-java/Jenkinsfile
New location weblink: https://download.jboss.org/jbosstools/vscode/stable/