### PR TITLE
fix: [APPAI-1643][Golang][LSP][VS Code] SA report adds build manifest package as dependency in go.mod

### DIFF
--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -333,11 +333,11 @@ export module ProjectDataProvider {
 
       const cmd: string = [
         `cd`,
-        `"${vscodeRootpath}" &&`,
+        `&&`,
         Utils.getGoExecutable(),
         `run`,
         `github.com/fabric8-analytics/cli-tools/gomanifest`,
-        `.`,
+        `"${vscodeRootpath}"`,
         `"${goGraphFilePath}"`,
       ].join(' ');
 


### PR DESCRIPTION
SA report adds build manifest package as dependency in go.mod. Runing build manifest command on non-project root folder avoid go.mod update.

Jira ticket :: https://issues.redhat.com/browse/APPAI-1643