### PR TITLE
fix: [APPAI-1650][Golang] SA gives error on few operating system

### DIFF
--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -342,6 +342,7 @@ export module ProjectDataProvider {
         `github.com/fabric8-analytics/cli-tools/gomanifest`,
         `"${vscodeRootpath}"`,
         `"${goGraphFilePath}"`,
+        `"${Utils.getGoExecutable()}"`
       ].join(' ');
 
       console.log('CMD : ' + cmd);

--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -332,7 +332,10 @@ export module ProjectDataProvider {
       }
 
       const cmd: string = [
-        `cd`,
+        Utils.getGoExecutable(),
+        `get`,
+        `-u`,
+        `github.com/fabric8-analytics/cli-tools/gomanifest`,
         `&&`,
         Utils.getGoExecutable(),
         `run`,


### PR DESCRIPTION
Modified go manifest generation command to avoid usage of 'cd' which was giving problem on some systems. Also now command gets gomanifest package first and then runs it. This also avoids updating go.mod file.

Jira ticket :: https://issues.redhat.com/browse/APPAI-1650 