### PR TITLE
fix: Update status bar to have concise text

### DIFF
--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -55,7 +55,7 @@ class CANotification {
       const finalStatus = [this.vulnCountText(), this.exploitCountText()].filter(t => t.length > 0).join(`, `);
       return `$(warning) Found ${finalStatus}`;
     }
-    return `$(check) No known vulnerabilties`;
+    return `$(shield)$(check)`;
   }
 }
 

--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -13,7 +13,7 @@ class CANotification {
   constructor(respData: any) {
     this.diagCount = respData.diagCount || 0;
     this.done = respData.done === true;
-    const vulnCount = respData.vulnCount || {vulnerabilityCount: 0, advisoryCount: 0, exploitCount: 0};
+    const vulnCount = respData.vulnCount || { vulnerabilityCount: 0, advisoryCount: 0, exploitCount: 0 };
     this.vulnerabilityCount = vulnCount.vulnerabilityCount;
     this.advisoryCount = vulnCount.advisoryCount;
     this.exploitCount = vulnCount.exploitCount;
@@ -40,22 +40,22 @@ class CANotification {
 
   private vulnCountText(): string {
     const vulns = this.vulnerabilityCount + this.advisoryCount;
-    return vulns > 0 ? `${vulns} vulns` : ``;
+    return vulns > 0 ? `${vulns} ${vulns == 1 ? 'vulnerability' : 'vulnerabilities'}` : ``;
   }
 
   private exploitCountText(): string {
-    return this.exploitCount > 0 ? `${this.exploitCount} exploits` : ``;
+    return this.exploitCount > 0 ? `${this.exploitCount} exploit${this.exploitCount == 1 ? '' : 's'}` : ``;
   }
 
   public statusText(): string {
     if (!this.isDone()) {
-      return `$(sync~spin) vuln analysis in progress`;
+      return `$(sync~spin) Dependency Analysis in progress`;
     }
     if (this.hasWarning()) {
       const finalStatus = [this.vulnCountText(), this.exploitCountText()].filter(t => t.length > 0).join(`, `);
-      return `$(warning) ${finalStatus} found in ${this.depCount} deps`;
+      return `$(warning) Found ${finalStatus}`;
     }
-    return `$(thumbsup) no vulns found in ${this.depCount} deps`;
+    return `$(check) No known vulnerabilties`;
   }
 }
 

--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -49,7 +49,7 @@ class CANotification {
 
   public statusText(): string {
     if (!this.isDone()) {
-      return `$(sync~spin) Dependency Analysis in progress`;
+      return `$(sync~spin) Dependency analysis in progress`;
     }
     if (this.hasWarning()) {
       const finalStatus = [this.vulnCountText(), this.exploitCountText()].filter(t => t.length > 0).join(`, `);

--- a/src/caStatusBarProvider.ts
+++ b/src/caStatusBarProvider.ts
@@ -15,15 +15,15 @@ class CAStatusBarProvider implements Disposable {
     public showSummary(text: string): void {
         this.statusBarItem.text = text;
         this.statusBarItem.command = {
-            title: StatusMessages.FULL_STACK_PROMPT_BUTTON,
+            title: StatusMessages.FULL_STACK_PROMPT_STATUS_BAR_TEXT,
             command: Commands.TRIGGER_FULL_STACK_ANALYSIS,
         };
-        this.statusBarItem.tooltip = StatusMessages.FULL_STACK_PROMPT_BUTTON;
+        this.statusBarItem.tooltip = StatusMessages.FULL_STACK_PROMPT_STATUS_BAR_TEXT;
         this.statusBarItem.show();
     }
 
     public setError(): void {
-        this.statusBarItem.text = `$(thumbsdown) analysis failed due to error`;
+        this.statusBarItem.text = `$(error) Dependency Analysis has failed`;
         this.statusBarItem.command = {
             title: StatusMessages.FULL_STACK_PROMPT_BUTTON,
             command: Commands.TRIGGER_STACK_LOGS,

--- a/src/caStatusBarProvider.ts
+++ b/src/caStatusBarProvider.ts
@@ -23,7 +23,7 @@ class CAStatusBarProvider implements Disposable {
     }
 
     public setError(): void {
-        this.statusBarItem.text = `$(error) Dependency Analysis has failed`;
+        this.statusBarItem.text = `$(error) Dependency analysis has failed`;
         this.statusBarItem.command = {
             title: StatusMessages.FULL_STACK_PROMPT_BUTTON,
             command: Commands.TRIGGER_STACK_LOGS,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,7 +123,7 @@ export function activate(context: vscode.ExtensionContext) {
         lspClient.onNotification('caError', respData => {
           const notification = new CANotification(respData);
           caStatusBarProvider.setError();
-          if (canShowPopup(respData)) {
+          if (canShowPopup(notification)) {
             vscode.window.showErrorMessage(respData.data);
             // prevent further popups.
             notifiedFiles.add(notification.origin());

--- a/src/statusMessages.ts
+++ b/src/statusMessages.ts
@@ -5,6 +5,7 @@
  */
 export namespace StatusMessages {
   export const FULL_STACK_PROMPT_BUTTON = `Click here for Detailed Vulnerability Report`;
+  export const FULL_STACK_PROMPT_STATUS_BAR_TEXT = `Open the detailed vulnerability report`;
   export const EXT_TITLE = `Dependency Analytics`;
   export const WIN_RESOLVING_DEPENDENCIES = `Resolving application dependencies...`;
   export const WIN_ANALYZING_DEPENDENCIES = `Analyzing application dependencies...`;


### PR DESCRIPTION
Singular/plural cases are handled:

<img width="156" alt="Screenshot 2020-12-18 at 3 18 52 PM" src="https://user-images.githubusercontent.com/3874763/102600075-58e64680-4144-11eb-92c9-470fc4450b50.png">
<img width="229" alt="Screenshot 2020-12-18 at 3 19 55 PM" src="https://user-images.githubusercontent.com/3874763/102600175-7ddab980-4144-11eb-9147-a49f3a32f6fc.png">

No vulnerabilities case:
<img width="41" alt="Screenshot 2020-12-18 at 3 41 28 PM" src="https://user-images.githubusercontent.com/3874763/102602409-81237480-4147-11eb-91f6-c58576fe80e1.png">

Changes are made based on the discussion with @fbricon.

Fixes https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/434