### PR TITLE
fix: Use concise text for CA popup

### DIFF
--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -35,7 +35,8 @@ class CANotification {
   }
 
   public popupText(): string {
-    return this.text;
+    // replace texts inside $(..)
+    return this.statusText().replace(/\$\((.*?)\)/g, '');
   }
 
   private vulnCountText(): string {
@@ -46,22 +47,12 @@ class CANotification {
     return this.exploitCount > 0 ? `${this.exploitCount} exploit${this.exploitCount == 1 ? '' : 's'}` : ``;
   }
 
-  private advisoryText(): string {
-    return this.advisoryCount > 0 ? `${this.advisoryCount} ${this.advisoryCount == 1 ? 'advisory' : 'advisories'}` : ``;
-  }
-
-  public plainStatusText(): string {
-    // replace texts inside $(..)
-    return this.statusText().replace(/\$\((.*?)\)/g, '');
-  }
-
   public statusText(): string {
     if (!this.isDone()) {
       return `$(sync~spin) Dependency analysis in progress`;
     }
     if (this.hasWarning()) {
-      let finalStatus = [this.vulnCountText(), this.advisoryText(), this.exploitCountText()].filter(t => t.length > 0).join(`, `);
-      finalStatus = finalStatus.replace(/(\b,\s\b)(?!.*\1)/g, ' & ');
+      const finalStatus = [this.vulnCountText(), this.exploitCountText()].filter(t => t.length > 0).join(`, `);
       return `$(warning) Found ${finalStatus}`;
     }
     return `$(shield)$(check)`;

--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -40,7 +40,8 @@ class CANotification {
   }
 
   private vulnCountText(): string {
-    return this.vulnerabilityCount > 0 ? `${this.vulnerabilityCount} ${this.vulnerabilityCount == 1 ? 'vulnerability' : 'vulnerabilities'}` : ``;
+    const vulns = this.vulnerabilityCount + this.advisoryCount;
+    return vulns > 0 ? `${vulns} ${vulns == 1 ? 'vulnerability' : 'vulnerabilities'}` : ``;
   }
 
   private exploitCountText(): string {

--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -39,12 +39,20 @@ class CANotification {
   }
 
   private vulnCountText(): string {
-    const vulns = this.vulnerabilityCount + this.advisoryCount;
-    return vulns > 0 ? `${vulns} ${vulns == 1 ? 'vulnerability' : 'vulnerabilities'}` : ``;
+    return this.vulnerabilityCount > 0 ? `${this.vulnerabilityCount} ${this.vulnerabilityCount == 1 ? 'vulnerability' : 'vulnerabilities'}` : ``;
   }
 
   private exploitCountText(): string {
     return this.exploitCount > 0 ? `${this.exploitCount} exploit${this.exploitCount == 1 ? '' : 's'}` : ``;
+  }
+
+  private advisoryText(): string {
+    return this.advisoryCount > 0 ? `${this.advisoryCount} ${this.advisoryCount == 1 ? 'advisory' : 'advisories'}` : ``;
+  }
+
+  public plainStatusText(): string {
+    // replace texts inside $(..)
+    return this.statusText().replace(/\$\((.*?)\)/g, '');
   }
 
   public statusText(): string {
@@ -52,7 +60,8 @@ class CANotification {
       return `$(sync~spin) Dependency analysis in progress`;
     }
     if (this.hasWarning()) {
-      const finalStatus = [this.vulnCountText(), this.exploitCountText()].filter(t => t.length > 0).join(`, `);
+      let finalStatus = [this.vulnCountText(), this.advisoryText(), this.exploitCountText()].filter(t => t.length > 0).join(`, `);
+      finalStatus = finalStatus.replace(/(\b,\s\b)(?!.*\1)/g, ' & ');
       return `$(warning) Found ${finalStatus}`;
     }
     return `$(shield)$(check)`;

--- a/src/caStatusBarProvider.ts
+++ b/src/caStatusBarProvider.ts
@@ -15,17 +15,17 @@ class CAStatusBarProvider implements Disposable {
     public showSummary(text: string): void {
         this.statusBarItem.text = text;
         this.statusBarItem.command = {
-            title: StatusMessages.FULL_STACK_PROMPT_STATUS_BAR_TEXT,
+            title: StatusMessages.FULL_STACK_PROMPT_TEXT,
             command: Commands.TRIGGER_FULL_STACK_ANALYSIS,
         };
-        this.statusBarItem.tooltip = StatusMessages.FULL_STACK_PROMPT_STATUS_BAR_TEXT;
+        this.statusBarItem.tooltip = StatusMessages.FULL_STACK_PROMPT_TEXT;
         this.statusBarItem.show();
     }
 
     public setError(): void {
         this.statusBarItem.text = `$(error) Dependency analysis has failed`;
         this.statusBarItem.command = {
-            title: StatusMessages.FULL_STACK_PROMPT_BUTTON,
+            title: StatusMessages.LSP_FAILURE_TEXT,
             command: Commands.TRIGGER_STACK_LOGS,
         };
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,7 +104,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         const showVulnerabilityFoundPrompt = async (msg: string) => {
-          const selection = await vscode.window.showInformationMessage(`${msg}. Powered by [Snyk](${registrationURL})`, StatusMessages.FULL_STACK_PROMPT_BUTTON);
+          const selection = await vscode.window.showWarningMessage(`${msg}. Powered by [Snyk](${registrationURL})`, StatusMessages.FULL_STACK_PROMPT_BUTTON);
           if (selection === StatusMessages.FULL_STACK_PROMPT_BUTTON) {
             vscode.commands.executeCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS);
           }
@@ -114,7 +114,7 @@ export function activate(context: vscode.ExtensionContext) {
           const notification = new CANotification(respData);
           caStatusBarProvider.showSummary(notification.statusText());
           if (canShowPopup(notification)) {
-            showVulnerabilityFoundPrompt(notification.popupText());
+            showVulnerabilityFoundPrompt(notification.plainStatusText());
             // prevent further popups.
             notifiedFiles.add(notification.origin());
           }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,8 +104,8 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         const showVulnerabilityFoundPrompt = async (msg: string) => {
-          const selection = await vscode.window.showWarningMessage(`${msg}. Powered by [Snyk](${registrationURL})`, StatusMessages.FULL_STACK_PROMPT_BUTTON);
-          if (selection === StatusMessages.FULL_STACK_PROMPT_BUTTON) {
+          const selection = await vscode.window.showWarningMessage(`${msg}. Powered by [Snyk](${registrationURL})`, StatusMessages.FULL_STACK_PROMPT_TEXT);
+          if (selection === StatusMessages.FULL_STACK_PROMPT_TEXT) {
             vscode.commands.executeCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS);
           }
         };
@@ -114,7 +114,7 @@ export function activate(context: vscode.ExtensionContext) {
           const notification = new CANotification(respData);
           caStatusBarProvider.showSummary(notification.statusText());
           if (canShowPopup(notification)) {
-            showVulnerabilityFoundPrompt(notification.plainStatusText());
+            showVulnerabilityFoundPrompt(notification.popupText());
             // prevent further popups.
             notifiedFiles.add(notification.origin());
           }
@@ -123,11 +123,7 @@ export function activate(context: vscode.ExtensionContext) {
         lspClient.onNotification('caError', respData => {
           const notification = new CANotification(respData);
           caStatusBarProvider.setError();
-          if (canShowPopup(notification)) {
-            vscode.window.showErrorMessage(respData.data);
-            // prevent further popups.
-            notifiedFiles.add(notification.origin());
-          }
+          vscode.window.showErrorMessage(respData.data);
         });
       });
       context.subscriptions.push(

--- a/src/statusMessages.ts
+++ b/src/statusMessages.ts
@@ -4,8 +4,8 @@
  * Commonly used messages
  */
 export namespace StatusMessages {
-  export const FULL_STACK_PROMPT_BUTTON = `Click here for Detailed Vulnerability Report`;
-  export const FULL_STACK_PROMPT_STATUS_BAR_TEXT = `Open the detailed vulnerability report`;
+  export const FULL_STACK_PROMPT_TEXT = `Open the detailed vulnerability report`;
+  export const LSP_FAILURE_TEXT = `Open the output window`;
   export const EXT_TITLE = `Dependency Analytics`;
   export const WIN_RESOLVING_DEPENDENCIES = `Resolving application dependencies...`;
   export const WIN_ANALYZING_DEPENDENCIES = `Analyzing application dependencies...`;


### PR DESCRIPTION
- Update popup to show concise text (in sync with status bar text)
- Fix popup full stack report label to be consistent with status tool tip
- Don’t silence error popup

<img width="1680" alt="Screenshot 2020-12-23 at 12 49 26 PM" src="https://user-images.githubusercontent.com/3874763/102970314-4d689600-451d-11eb-9d38-78fcf6eeab6f.png">

Also fixes https://issues.redhat.com/browse/APPAI-1679