### PR TITLE
chore: Fix OVSX publish failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,11 +49,11 @@ node('rhel8'){
 	stage "Publish to Marketplace"
 	unstash 'vsix';
 
+	def vsix = findFiles(glob: '**.vsix')
 	// VS Code Marketplace
-	withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
-		def vsix = findFiles(glob: '**.vsix')
-		sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
-	}
+	// withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
+	// 	sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
+	// }
 
 	// Open-vsx Marketplace
 	sh "npm install -g ovsx"


### PR DESCRIPTION
Publish to VSCode market place has been temporarily disabled to passthrough OVSX publish step.