### PR TITLE
feat: Get python path from ms-python extension

### DIFF
--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -4,6 +4,7 @@ import * as paths from 'path';
 import * as os from 'os';
 import { exec } from 'child_process';
 import { Config } from './config';
+import { getSelectedInterpreterPath } from './msPythonExtension';
 import { StatusMessages } from './statusMessages';
 import { outputChannelDep, initOutputChannel } from './extension';
 import { Commands } from './commands';
@@ -246,23 +247,15 @@ export module ProjectDataProvider {
   };
 
   export const effectivef8Pypi = item => {
-    return new Promise((resolve, reject) => {
+    return new Promise(async(resolve, reject) => {
       const outputChannelDep = isOutputChannelActivated();
       outputChannelDep.clearOutputChannel();
       let vscodeRootpath = item.replace('requirements.txt', '');
       const filepath = paths.join(vscodeRootpath, 'target', 'pylist.json');
       let reqTxtFilePath = paths.join(vscodeRootpath, 'requirements.txt');
       let dir = paths.join(vscodeRootpath, 'target');
-      let pyPiInterpreter = Config.getPypiExecutable();
-      if (
-        pyPiInterpreter &&
-        pyPiInterpreter.indexOf('${workspaceFolder}') !== -1
-      ) {
-        pyPiInterpreter = pyPiInterpreter.replace(
-          '${workspaceFolder}',
-          vscodeRootpath
-        );
-      }
+      const uri = vscode.Uri.parse(reqTxtFilePath);
+      const pyPiInterpreter = await getSelectedInterpreterPath(outputChannelDep.getOutputChannel(), uri);
 
       if (!pyPiInterpreter) {
         vscode.window

--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -255,7 +255,7 @@ export module ProjectDataProvider {
       let reqTxtFilePath = paths.join(vscodeRootpath, 'requirements.txt');
       let dir = paths.join(vscodeRootpath, 'target');
       const uri = vscode.Uri.parse(reqTxtFilePath);
-      const pyPiInterpreter = await getSelectedInterpreterPath(outputChannelDep.getOutputChannel(), uri);
+      const pyPiInterpreter = await getSelectedInterpreterPath(outputChannelDep.getOutputChannel(), uri) || Config.getPythonExecutable();
 
       if (!pyPiInterpreter) {
         vscode.window

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,7 @@ export namespace Config {
     return npmPath ? `"${npmPath}"` : 'npm';
   }
 
-  export function getPypiExecutable(): string {
+  export function getPythonExecutable(): string {
     const pypiPath: string = vscode.workspace
       .getConfiguration('python')
       .get('pythonPath');

--- a/src/msPythonExtension.ts
+++ b/src/msPythonExtension.ts
@@ -1,0 +1,40 @@
+import { OutputChannel, Uri, extensions } from 'vscode';
+import { Config } from './config';
+
+export async function getSelectedInterpreterPath(
+  outputChannel: OutputChannel,
+  scopeUri: Uri | undefined
+): Promise<string | undefined> {
+  try {
+    const extension = extensions.getExtension('ms-python.python');
+    if (!extension) {
+      outputChannel.appendLine('Python extension not found');
+    } else {
+      if (!extension.isActive) {
+        outputChannel.appendLine('Waiting for Python extension to load');
+        await extension.activate();
+        outputChannel.appendLine('Python extension loaded');
+      }
+
+      const execDetails = await extension.exports.settings.getExecutionDetails(scopeUri);
+      let result: string | undefined;
+      if (execDetails.execCommand && execDetails.execCommand.length > 0) {
+        result = execDetails.execCommand[0];
+      }
+
+      if (!result) {
+        outputChannel.appendLine(`No pythonPath provided by Python extension`);
+      } else {
+        outputChannel.appendLine(`Received pythonPath from Python extension: ${result}`);
+      }
+
+      return result || Config.getPypiExecutable();
+    }
+  } catch (error) {
+    outputChannel.appendLine(
+      `Exception occurred when attempting to read pythonPath from Python extension: ${JSON.stringify(error)}`
+    );
+  }
+
+  return Config.getPypiExecutable();
+}

--- a/src/msPythonExtension.ts
+++ b/src/msPythonExtension.ts
@@ -1,5 +1,4 @@
 import { OutputChannel, Uri, extensions } from 'vscode';
-import { Config } from './config';
 
 export async function getSelectedInterpreterPath(
   outputChannel: OutputChannel,
@@ -28,7 +27,7 @@ export async function getSelectedInterpreterPath(
         outputChannel.appendLine(`Received pythonPath from Python extension: ${result}`);
       }
 
-      return result || Config.getPypiExecutable();
+      return result;
     }
   } catch (error) {
     outputChannel.appendLine(
@@ -36,5 +35,5 @@ export async function getSelectedInterpreterPath(
     );
   }
 
-  return Config.getPypiExecutable();
+  return undefined;
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -29,7 +29,7 @@ suite('Config module', () => {
   });
 
   test('getPypiExecutable should return python', () => {
-    let pypiPath = Config.getPypiExecutable();
-    expect(pypiPath).equals('python');
+    let python = Config.getPythonExecutable();
+    expect(python).equals('python');
   });
 });

--- a/test/projectDataProvider.test.ts
+++ b/test/projectDataProvider.test.ts
@@ -113,7 +113,7 @@ suite('projectDataProvider Modules', () => {
       workspaceFolder.uri.fsPath
     );
     expect(effectivef8PypiPR).contains('target/pylist.json');
-    expect(stubExec).callCount(1);
+    expect(stubExec).called;
   });
 
   test('effectivef8Golang should return success', async () => {


### PR DESCRIPTION
Prior to this PR, we were relying only on `python.pythonPath` which is
extremely hard to maintain if user switches between multiple projects with
different python versions. Also our extension doesn't automatically
finds venv.

ms-python[1] extension scans entire workspace and discovers virtual env. It
also provides nice interface to select and switch between various venvs.
This PR makes use of the APIs[2] exposed by ms-python to fetch the
selected interpreter path.

Extension fallbacks to default behaviour incase if there is no ms-python
installed.

This also should work seamlessly when user has multi-root vscode workspaces[3].

TODO: Recommend users to install ms-python if it is not
already installed.

[1] https://marketplace.visualstudio.com/items?itemName=ms-python.python
[2] https://github.com/microsoft/vscode-python/blob/c1a8d94c6b8caa658aa99109111a3ee3551c8fe0/src/client/api.ts#L67
[3] https://code.visualstudio.com/docs/editor/multi-root-workspaces
