### PR TITLE
fix: [APPAI-1838] [Golang] SA does not trigger on windows

### DIFF
--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -316,7 +316,8 @@ export module ProjectDataProvider {
     return new Promise((resolve, reject) => {
       const outputChannelDep = isOutputChannelActivated();
       outputChannelDep.clearOutputChannel();
-      let vscodeRootpath = item.replace('go.mod', '');
+      // Remove trailling '/' or '\' in order to provide perfect folder path to gomanifest
+      let vscodeRootpath = item.substring(0, item.length - 1);
       let targetDir = paths.join(vscodeRootpath, 'target');
       const goGraphFilePath = paths.join(targetDir, 'golist.json');
 
@@ -345,7 +346,7 @@ export module ProjectDataProvider {
         cmd,
         { maxBuffer: 1024 * 1200, env: Object.assign({}, process.env, { "GOPATH": goPath }) },
         (error: Error, _stdout: string, _stderr: string): void => {
-          let outputMsg = `\n STDOUT : ${_stdout} \n STDERR : ${_stderr}`;
+          let outputMsg = `\n STDOUT : ${_stdout} \n STDERR : ${_stderr} \n error : ${error}`;
           outputChannelDep.addMsgOutputChannel(outputMsg);
           if (error) {
             vscode.window

--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -8,6 +8,7 @@ import { getSelectedInterpreterPath } from './msPythonExtension';
 import { StatusMessages } from './statusMessages';
 import { outputChannelDep, initOutputChannel } from './extension';
 import { Commands } from './commands';
+import { dirname } from 'path';
 
 export module ProjectDataProvider {
   export const isOutputChannelActivated = (): any => {
@@ -312,12 +313,11 @@ export module ProjectDataProvider {
     });
   };
 
-  export const effectivef8Golang = item => {
+  export const effectivef8Golang = manifestPath => {
     return new Promise((resolve, reject) => {
       const outputChannelDep = isOutputChannelActivated();
       outputChannelDep.clearOutputChannel();
-      // Remove trailling '/' or '\' in order to provide perfect folder path to gomanifest
-      let vscodeRootpath = item.replace(/[\/|\\]$/, '');
+      let vscodeRootpath = dirname(manifestPath);
       let targetDir = paths.join(vscodeRootpath, 'target');
       const goGraphFilePath = paths.join(targetDir, 'golist.json');
 

--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -317,7 +317,7 @@ export module ProjectDataProvider {
       const outputChannelDep = isOutputChannelActivated();
       outputChannelDep.clearOutputChannel();
       // Remove trailling '/' or '\' in order to provide perfect folder path to gomanifest
-      let vscodeRootpath = item.substring(0, item.length - 1);
+      let vscodeRootpath = item.replace(/[\/|\\]$/, '');
       let targetDir = paths.join(vscodeRootpath, 'target');
       const goGraphFilePath = paths.join(targetDir, 'golist.json');
 

--- a/src/stackanalysismodule.ts
+++ b/src/stackanalysismodule.ts
@@ -147,7 +147,7 @@ export module stackanalysismodule {
       effectiveF8Var = 'effectivef8Pypi';
     } else if (ecosystem === 'golang') {
       argumentList = uri
-        ? uri.fsPath.split('go.mod')[0]
+        ? uri.fsPath
         : workspaceFolder.uri.fsPath;
       effectiveF8Var = 'effectivef8Golang';
     }

--- a/test/projectDataProvider.test.ts
+++ b/test/projectDataProvider.test.ts
@@ -122,7 +122,7 @@ suite('projectDataProvider Modules', () => {
       .stub(child_process, 'exec')
       .yields(null, 'success', 'success');
     let effectivef8GolangPR = await ProjectDataProvider.effectivef8Golang(
-      workspaceFolder.uri.fsPath
+      paths.join(workspaceFolder.uri.fsPath, "go.mod")
     );
     expect(effectivef8GolangPR).contains('target/golist.json');
     expect(stubExec).callCount(1);


### PR DESCRIPTION
Stack analyses does not get trigger for windows for golang. The issue was with folder path passed to the `gomanifest` binary to generate `golist.json`. The last '\' amd '/' in path caused command line parameter to be passed wrongly. 

Fixes user issue https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/506
Jira ticket :: https://issues.redhat.com/browse/APPAI-1838

Changes were tested on Linux, WIndows and Mac with go1.16 and go1.14