### PR TITLE
fix: send component_analysis_done only if api call is made

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-developer/vscode-redhat-telemetry": "0.0.13",
-        "fabric8-analytics-lsp-server": "^0.4.26",
+        "fabric8-analytics-lsp-server": "^0.4.29",
         "fs": "0.0.1-security",
         "node-fetch": "^2.6.0",
         "path": "0.12.7",
@@ -2371,9 +2371,9 @@
       ]
     },
     "node_modules/fabric8-analytics-lsp-server": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.4.26.tgz",
-      "integrity": "sha512-BmBwXA2lXBtHnux0hRfT/urL5IvtkdvDynKem594pdbTWUY0McesD00Bb4GBfvjB236NadC1Ibv/Z1ZXAwvr2A==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.4.29.tgz",
+      "integrity": "sha512-MDnkJMb2dzXx9LeiE8rV8k7XKv6EHlIeKUOWoBSiHET5G050wzuS+HyXdFGCv3vFnZi8KDtcakZapNrnIPoupA==",
       "dependencies": {
         "@xml-tools/ast": "^5.0.3",
         "@xml-tools/parser": "1.0.9",
@@ -10026,9 +10026,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fabric8-analytics-lsp-server": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.4.26.tgz",
-      "integrity": "sha512-BmBwXA2lXBtHnux0hRfT/urL5IvtkdvDynKem594pdbTWUY0McesD00Bb4GBfvjB236NadC1Ibv/Z1ZXAwvr2A==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/fabric8-analytics-lsp-server/-/fabric8-analytics-lsp-server-0.4.29.tgz",
+      "integrity": "sha512-MDnkJMb2dzXx9LeiE8rV8k7XKv6EHlIeKUOWoBSiHET5G050wzuS+HyXdFGCv3vFnZi8KDtcakZapNrnIPoupA==",
       "requires": {
         "@xml-tools/ast": "^5.0.3",
         "@xml-tools/parser": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
   },
   "dependencies": {
     "@redhat-developer/vscode-redhat-telemetry": "0.0.13",
-    "fabric8-analytics-lsp-server": "^0.4.26",
+    "fabric8-analytics-lsp-server": "^0.4.29",
     "fs": "0.0.1-security",
     "node-fetch": "^2.6.0",
     "path": "0.12.7",

--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -10,9 +10,13 @@ class CANotification {
   private depCount: number;
   private uri: string;
   private text: string;
+  private cacheHitCount: number;
+  private cacheMissCount: number;
   constructor(respData: any) {
     this.diagCount = respData.diagCount || 0;
     this.done = respData.done === true;
+    this.cacheHitCount = respData?.cacheHitCount || 0;
+    this.cacheMissCount = respData?.cacheMissCount || 0;
     const vulnCount = respData.vulnCount || { vulnerabilityCount: 0, advisoryCount: 0, exploitCount: 0 };
     this.vulnerabilityCount = vulnCount.vulnerabilityCount;
     this.advisoryCount = vulnCount.advisoryCount;
@@ -28,6 +32,10 @@ class CANotification {
 
   public isDone(): boolean {
     return this.done;
+  }
+
+  public didCallBackend(): boolean {
+    return this.cacheMissCount > 0;
   }
 
   public hasWarning(): boolean {

--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -15,8 +15,8 @@ class CANotification {
   constructor(respData: any) {
     this.diagCount = respData.diagCount || 0;
     this.done = respData.done === true;
-    this.cacheHitCount = respData?.cacheHitCount || 0;
-    this.cacheMissCount = respData?.cacheMissCount || 0;
+    this.cacheHitCount = respData.cacheHitCount || 0;
+    this.cacheMissCount = respData.cacheMissCount || 0;
     const vulnCount = respData.vulnCount || { vulnerabilityCount: 0, advisoryCount: 0, exploitCount: 0 };
     this.vulnerabilityCount = vulnCount.vulnerabilityCount;
     this.advisoryCount = vulnCount.advisoryCount;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,8 +126,9 @@ export function activate(context: vscode.ExtensionContext) {
             // prevent further popups.
             notifiedFiles.add(notification.origin());
           }
-          notification.isDone() &&
-          record(TelemetryActions.componentAnalysisDone, {fileName: path.basename(notification.origin())});
+          if (notification.didCallBackend()) {
+            record(TelemetryActions.componentAnalysisDone, {fileName: path.basename(notification.origin())});
+          }
         });
 
         lspClient.onNotification('caError', respData => {


### PR DESCRIPTION
if `cacheMissCount > 0` evaluates to true then there was a api call from lsp to the backend. Record this as 
`component_analysis_done` event.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>