### PR TITLE
fix: hide internal analytics commands from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "commands": [
       {
         "command": "extension.fabric8AnalyticsWidgetFullStack",
-        "title": "Dependency Analytics Report ..."
+        "title": "Dependency Analytics Report...",
+        "category": "Dependency Analytics"
       },
       {
         "command": "extension.fabric8AnalyticsWidgetFullStackFromPieBtn",
@@ -97,7 +98,8 @@
       },
       {
         "command": "extension.fabric8AnalyticsStackLogs",
-        "title": "Dependency Analytics Logs ..."
+        "title": "Dependency Analytics Logs...",
+        "category": "Dependency Analytics"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vscode": "^1.50.0"
   },
   "activationEvents": [
-    "onCommand:extension.fabric8AnalyticsWidgetFullStack",
+    "onCommand:extension.stackAnalysis",
     "workspaceContains:**/package.json",
     "workspaceContains:**/pom.xml",
     "workspaceContains:**/requirements.txt",
@@ -76,12 +76,12 @@
     ],
     "commands": [
       {
-        "command": "extension.fabric8AnalyticsWidgetFullStack",
-        "title": "Dependency Analytics Report...",
+        "command": "extension.stackAnalysis",
+        "title": "Stack Report...",
         "category": "Dependency Analytics"
       },
       {
-        "command": "extension.fabric8AnalyticsWidgetFullStackFromPieBtn",
+        "command": "extension.stackAnalysisFromPieBtn",
         "title": "Open Vulnerability Report",
         "icon": {
           "light": "icon/report-icon.png",
@@ -89,89 +89,89 @@
         }
       },
       {
-        "command": "extension.fabric8AnalyticsWidgetFullStackFromEditor",
+        "command": "extension.stackAnalysisFromEditor",
         "title": "Dependency Analytics Report..."
       },
       {
-        "command": "extension.fabric8AnalyticsWidgetFullStackFromExplorer",
+        "command": "extension.stackAnalysisFromExplorer",
         "title": "Dependency Analytics Report..."
       },
       {
         "command": "extension.fabric8AnalyticsStackLogs",
-        "title": "Dependency Analytics Logs...",
+        "title": "Debug logs",
         "category": "Dependency Analytics"
       }
     ],
     "menus": {
       "editor/title": [
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromPieBtn",
+          "command": "extension.stackAnalysisFromPieBtn",
           "when": "resourceFilename == pom.xml",
           "group": "navigation"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromPieBtn",
+          "command": "extension.stackAnalysisFromPieBtn",
           "when": "resourceFilename == package.json",
           "group": "navigation"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromPieBtn",
+          "command": "extension.stackAnalysisFromPieBtn",
           "when": "resourceFilename == requirements.txt",
           "group": "navigation"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromPieBtn",
+          "command": "extension.stackAnalysisFromPieBtn",
           "when": "resourceFilename == go.mod",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromExplorer",
+          "command": "extension.stackAnalysisFromExplorer",
           "when": "resourceFilename == package.json"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromExplorer",
+          "command": "extension.stackAnalysisFromExplorer",
           "when": "resourceFilename == pom.xml"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromExplorer",
+          "command": "extension.stackAnalysisFromExplorer",
           "when": "resourceFilename == requirements.txt"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromExplorer",
+          "command": "extension.stackAnalysisFromExplorer",
           "when": "resourceFilename == go.mod"
         }
       ],
       "editor/context": [
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromEditor",
+          "command": "extension.stackAnalysisFromEditor",
           "when": "resourceFilename == package.json"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromEditor",
+          "command": "extension.stackAnalysisFromEditor",
           "when": "resourceFilename == pom.xml"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromEditor",
+          "command": "extension.stackAnalysisFromEditor",
           "when": "resourceFilename == requirements.txt"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromEditor",
+          "command": "extension.stackAnalysisFromEditor",
           "when": "resourceFilename == go.mod"
         }
       ],
       "commandPalette": [
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromPieBtn",
+          "command": "extension.stackAnalysisFromPieBtn",
           "when": "false"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromEditor",
+          "command": "extension.stackAnalysisFromEditor",
           "when": "false"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStackFromExplorer",
+          "command": "extension.stackAnalysisFromExplorer",
           "when": "false"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vscode": "^1.50.0"
   },
   "activationEvents": [
-    "onCommand:extension.stackAnalysis",
+    "onCommand:fabric8.stackAnalysis",
     "workspaceContains:**/package.json",
     "workspaceContains:**/pom.xml",
     "workspaceContains:**/requirements.txt",
@@ -76,12 +76,12 @@
     ],
     "commands": [
       {
-        "command": "extension.stackAnalysis",
+        "command": "fabric8.stackAnalysis",
         "title": "Stack Report...",
         "category": "Dependency Analytics"
       },
       {
-        "command": "extension.stackAnalysisFromPieBtn",
+        "command": "fabric8.stackAnalysisFromPieBtn",
         "title": "Open Vulnerability Report",
         "icon": {
           "light": "icon/report-icon.png",
@@ -89,15 +89,15 @@
         }
       },
       {
-        "command": "extension.stackAnalysisFromEditor",
+        "command": "fabric8.stackAnalysisFromEditor",
         "title": "Dependency Analytics Report..."
       },
       {
-        "command": "extension.stackAnalysisFromExplorer",
+        "command": "fabric8.stackAnalysisFromExplorer",
         "title": "Dependency Analytics Report..."
       },
       {
-        "command": "extension.fabric8AnalyticsStackLogs",
+        "command": "fabric8.fabric8AnalyticsStackLogs",
         "title": "Debug logs",
         "category": "Dependency Analytics"
       }
@@ -105,73 +105,73 @@
     "menus": {
       "editor/title": [
         {
-          "command": "extension.stackAnalysisFromPieBtn",
+          "command": "fabric8.stackAnalysisFromPieBtn",
           "when": "resourceFilename == pom.xml",
           "group": "navigation"
         },
         {
-          "command": "extension.stackAnalysisFromPieBtn",
+          "command": "fabric8.stackAnalysisFromPieBtn",
           "when": "resourceFilename == package.json",
           "group": "navigation"
         },
         {
-          "command": "extension.stackAnalysisFromPieBtn",
+          "command": "fabric8.stackAnalysisFromPieBtn",
           "when": "resourceFilename == requirements.txt",
           "group": "navigation"
         },
         {
-          "command": "extension.stackAnalysisFromPieBtn",
+          "command": "fabric8.stackAnalysisFromPieBtn",
           "when": "resourceFilename == go.mod",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
-          "command": "extension.stackAnalysisFromExplorer",
+          "command": "fabric8.stackAnalysisFromExplorer",
           "when": "resourceFilename == package.json"
         },
         {
-          "command": "extension.stackAnalysisFromExplorer",
+          "command": "fabric8.stackAnalysisFromExplorer",
           "when": "resourceFilename == pom.xml"
         },
         {
-          "command": "extension.stackAnalysisFromExplorer",
+          "command": "fabric8.stackAnalysisFromExplorer",
           "when": "resourceFilename == requirements.txt"
         },
         {
-          "command": "extension.stackAnalysisFromExplorer",
+          "command": "fabric8.stackAnalysisFromExplorer",
           "when": "resourceFilename == go.mod"
         }
       ],
       "editor/context": [
         {
-          "command": "extension.stackAnalysisFromEditor",
+          "command": "fabric8.stackAnalysisFromEditor",
           "when": "resourceFilename == package.json"
         },
         {
-          "command": "extension.stackAnalysisFromEditor",
+          "command": "fabric8.stackAnalysisFromEditor",
           "when": "resourceFilename == pom.xml"
         },
         {
-          "command": "extension.stackAnalysisFromEditor",
+          "command": "fabric8.stackAnalysisFromEditor",
           "when": "resourceFilename == requirements.txt"
         },
         {
-          "command": "extension.stackAnalysisFromEditor",
+          "command": "fabric8.stackAnalysisFromEditor",
           "when": "resourceFilename == go.mod"
         }
       ],
       "commandPalette": [
         {
-          "command": "extension.stackAnalysisFromPieBtn",
+          "command": "fabric8.stackAnalysisFromPieBtn",
           "when": "false"
         },
         {
-          "command": "extension.stackAnalysisFromEditor",
+          "command": "fabric8.stackAnalysisFromEditor",
           "when": "false"
         },
         {
-          "command": "extension.stackAnalysisFromExplorer",
+          "command": "fabric8.stackAnalysisFromExplorer",
           "when": "false"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -158,6 +158,20 @@
           "command": "extension.fabric8AnalyticsWidgetFullStackFromEditor",
           "when": "resourceFilename == go.mod"
         }
+      ],
+      "commandPalette": [
+        {
+          "command": "extension.fabric8AnalyticsWidgetFullStackFromPieBtn",
+          "when": "false"
+        },
+        {
+          "command": "extension.fabric8AnalyticsWidgetFullStackFromEditor",
+          "when": "false"
+        },
+        {
+          "command": "extension.fabric8AnalyticsWidgetFullStackFromExplorer",
+          "when": "false"
+        }
       ]
     },
     "configurationAttributes": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,16 +7,15 @@ export namespace Commands {
   /**
    * Triggers Stack Analysis
    */
-  export const TRIGGER_FULL_STACK_ANALYSIS =
-    'extension.fabric8AnalyticsWidgetFullStack';
+  export const TRIGGER_FULL_STACK_ANALYSIS = 'extension.stackAnalysis';
   export const TRIGGER_FULL_STACK_ANALYSIS_FROM_STATUS_BAR =
-    'extension.fabric8AnalyticsWidgetFullStackFromStatusBar';
+    'extension.stackAnalysisFromStatusBar';
   export const TRIGGER_FULL_STACK_ANALYSIS_FROM_EXPLORER =
-    'extension.fabric8AnalyticsWidgetFullStackFromExplorer';
+    'extension.stackAnalysisFromExplorer';
   export const TRIGGER_FULL_STACK_ANALYSIS_FROM_PIE_BTN =
-    'extension.fabric8AnalyticsWidgetFullStackFromPieBtn';
+    'extension.stackAnalysisFromPieBtn';
   export const TRIGGER_FULL_STACK_ANALYSIS_FROM_EDITOR =
-    'extension.fabric8AnalyticsWidgetFullStackFromEditor';
+    'extension.stackAnalysisFromEditor';
   export const TRIGGER_LSP_EDIT = 'lsp.applyTextEdit';
   export const TRIGGER_STACK_LOGS = 'extension.fabric8AnalyticsStackLogs';
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,15 +7,15 @@ export namespace Commands {
   /**
    * Triggers Stack Analysis
    */
-  export const TRIGGER_FULL_STACK_ANALYSIS = 'extension.stackAnalysis';
+  export const TRIGGER_FULL_STACK_ANALYSIS = 'fabric8.stackAnalysis';
   export const TRIGGER_FULL_STACK_ANALYSIS_FROM_STATUS_BAR =
-    'extension.stackAnalysisFromStatusBar';
+    'fabric8.stackAnalysisFromStatusBar';
   export const TRIGGER_FULL_STACK_ANALYSIS_FROM_EXPLORER =
-    'extension.stackAnalysisFromExplorer';
+    'fabric8.stackAnalysisFromExplorer';
   export const TRIGGER_FULL_STACK_ANALYSIS_FROM_PIE_BTN =
-    'extension.stackAnalysisFromPieBtn';
+    'fabric8.stackAnalysisFromPieBtn';
   export const TRIGGER_FULL_STACK_ANALYSIS_FROM_EDITOR =
-    'extension.stackAnalysisFromEditor';
+    'fabric8.stackAnalysisFromEditor';
   export const TRIGGER_LSP_EDIT = 'lsp.applyTextEdit';
-  export const TRIGGER_STACK_LOGS = 'extension.fabric8AnalyticsStackLogs';
+  export const TRIGGER_STACK_LOGS = 'fabric8.fabric8AnalyticsStackLogs';
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -39,7 +39,7 @@ suite('Fabric8 Analytics Extension', () => {
           assert.equal(reason.name, 'Error');
           assert.equal(
             reason.message,
-            `Running the contributed command: 'extension.stackAnalysis' failed.`
+            `Running the contributed command: 'fabric8.stackAnalysis' failed.`
           );
         }
       );

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -15,7 +15,6 @@ suite('Fabric8 Analytics Extension', () => {
     assert.ok(true);
   }).timeout(1 * 60 * 1000);
 
-  
   test('should register all fabric8 commands', async function () {
     const FABRIC8_COMMANDS: string[] = [
       Commands.TRIGGER_FULL_STACK_ANALYSIS,
@@ -26,21 +25,23 @@ suite('Fabric8 Analytics Extension', () => {
       Commands.TRIGGER_FULL_STACK_ANALYSIS_FROM_STATUS_BAR,
     ];
     // @ts-ignore
-    assert.ok((await vscode.commands.getCommands(true)).includes(...FABRIC8_COMMANDS));
+    assert.ok(
+      (await vscode.commands.getCommands(true)).includes(...FABRIC8_COMMANDS)
+    );
   });
 
   test('should trigger fabric8-analytics full stack report activate', async () => {
     await vscode.commands
       .executeCommand(Commands.TRIGGER_FULL_STACK_ANALYSIS)
       .then(
-        res => {
+        (res) => {
           assert.ok(true);
         },
         (reason: any) => {
           assert.equal(reason.name, 'Error');
           assert.equal(
             reason.message,
-            `Running the contributed command: 'extension.fabric8AnalyticsWidgetFullStack' failed.`
+            `Running the contributed command: 'extension.stackAnalysis' failed.`
           );
         }
       );

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -25,9 +25,7 @@ suite('Fabric8 Analytics Extension', () => {
       Commands.TRIGGER_FULL_STACK_ANALYSIS_FROM_STATUS_BAR,
     ];
     // @ts-ignore
-    assert.ok(
-      (await vscode.commands.getCommands(true)).includes(...FABRIC8_COMMANDS)
-    );
+    assert.ok((await vscode.commands.getCommands(true)).includes(...FABRIC8_COMMANDS));
   });
 
   test('should trigger fabric8-analytics full stack report activate', async () => {

--- a/test/resources/sampleNodeApp/package.json
+++ b/test/resources/sampleNodeApp/package.json
@@ -50,7 +50,7 @@
   },
   "activationEvents": [
     "onCommand:extension.fabric8AnalyticsWidget",
-    "onCommand:extension.fabric8AnalyticsWidgetFullStack",
+    "onCommand:extension.stackAnalysis",
     "onLanguage:xml",
     "onLanguage:json"
   ],
@@ -98,7 +98,7 @@
       },
       {
         "key": "ctrl+k",
-        "command": "extension.fabric8AnalyticsWidgetFullStack",
+        "command": "extension.stackAnalysis",
         "title": "Generate application stack report on Workspace"
       }
     ],
@@ -109,12 +109,12 @@
           "when": "resourceLangId == xml"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStack"
+          "command": "extension.stackAnalysis"
         }
       ],
       "explorer/context": [
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStack"
+          "command": "extension.stackAnalysis"
         }
       ],
       "editor/context": [
@@ -123,7 +123,7 @@
           "when": "resourceLangId == xml"
         },
         {
-          "command": "extension.fabric8AnalyticsWidgetFullStack"
+          "command": "extension.stackAnalysis"
         },
         {
           "command": "extension.fabric8AnalyticsWidget",

--- a/test/resources/sampleNodeApp/package.json
+++ b/test/resources/sampleNodeApp/package.json
@@ -49,8 +49,8 @@
     "vscode": "^1.12.0"
   },
   "activationEvents": [
-    "onCommand:extension.fabric8AnalyticsWidget",
-    "onCommand:extension.stackAnalysis",
+    "onCommand:fabric8.fabric8AnalyticsWidget",
+    "onCommand:fabric8.stackAnalysis",
     "onLanguage:xml",
     "onLanguage:json"
   ],
@@ -93,40 +93,40 @@
     "commands": [
       {
         "key": "ctrl+j",
-        "command": "extension.fabric8AnalyticsWidget",
+        "command": "fabric8.fabric8AnalyticsWidget",
         "title": "Generate application stack report on manifest file"
       },
       {
         "key": "ctrl+k",
-        "command": "extension.stackAnalysis",
+        "command": "fabric8.stackAnalysis",
         "title": "Generate application stack report on Workspace"
       }
     ],
     "menus": {
       "editor/title": [
         {
-          "command": "extension.fabric8AnalyticsWidget",
+          "command": "fabric8.fabric8AnalyticsWidget",
           "when": "resourceLangId == xml"
         },
         {
-          "command": "extension.stackAnalysis"
+          "command": "fabric8.stackAnalysis"
         }
       ],
       "explorer/context": [
         {
-          "command": "extension.stackAnalysis"
+          "command": "fabric8.stackAnalysis"
         }
       ],
       "editor/context": [
         {
-          "command": "extension.fabric8AnalyticsWidget",
+          "command": "fabric8.fabric8AnalyticsWidget",
           "when": "resourceLangId == xml"
         },
         {
-          "command": "extension.stackAnalysis"
+          "command": "fabric8.stackAnalysis"
         },
         {
-          "command": "extension.fabric8AnalyticsWidget",
+          "command": "fabric8.fabric8AnalyticsWidget",
           "when": "resourceFilename == package.json"
         }
       ]


### PR DESCRIPTION
fixes https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/512