### PR TITLE
fix: vscode plugin

### DIFF
--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -10,6 +10,8 @@ import { outputChannelDep, initOutputChannel } from './extension';
 import { Commands } from './commands';
 import { dirname } from 'path';
 
+const GOMANIFEST_PKG = "github.com/fabric8-analytics/cli-tools/gomanifest";
+
 export module ProjectDataProvider {
   export const isOutputChannelActivated = (): any => {
     if (!outputChannelDep) {
@@ -321,9 +323,6 @@ export module ProjectDataProvider {
       let targetDir = paths.join(vscodeRootpath, 'target');
       const goGraphFilePath = paths.join(targetDir, 'golist.json');
 
-      const goPath = paths.join(os.tmpdir(), 'gomanifest');
-      const goManifestPath = paths.join(paths.join(goPath, 'bin'), 'gomanifest');
-
       if (!fs.existsSync(targetDir)) {
         fs.mkdirSync(targetDir);
       }
@@ -332,9 +331,11 @@ export module ProjectDataProvider {
         Config.getGoExecutable(),
         `get`,
         `-u`,
-        `github.com/fabric8-analytics/cli-tools/gomanifest`,
+        `"${GOMANIFEST_PKG}"`,
         `&&`,
-        `${goManifestPath}`,
+        Config.getGoExecutable(),
+        `run`,
+        `"${GOMANIFEST_PKG}"`,
         `"${vscodeRootpath}"`,
         `"${goGraphFilePath}"`,
         `"${Config.getGoExecutable()}"`,
@@ -344,7 +345,7 @@ export module ProjectDataProvider {
       outputChannelDep.addMsgOutputChannel('\n CMD :' + cmd);
       exec(
         cmd,
-        { maxBuffer: 1024 * 1200, env: Object.assign({}, process.env, { "GOPATH": goPath }) },
+        { cwd: vscodeRootpath, maxBuffer: 1024 * 1200, env: Object.assign({}, process.env) },
         (error: Error, _stdout: string, _stderr: string): void => {
           let outputMsg = `\n STDOUT : ${_stdout} \n STDERR : ${_stderr} \n error : ${error}`;
           outputChannelDep.addMsgOutputChannel(outputMsg);

--- a/src/ProjectDataProvider.ts
+++ b/src/ProjectDataProvider.ts
@@ -10,8 +10,6 @@ import { outputChannelDep, initOutputChannel } from './extension';
 import { Commands } from './commands';
 import { dirname } from 'path';
 
-const GOMANIFEST_PKG = "github.com/fabric8-analytics/cli-tools/gomanifest";
-
 export module ProjectDataProvider {
   export const isOutputChannelActivated = (): any => {
     if (!outputChannelDep) {
@@ -329,13 +327,10 @@ export module ProjectDataProvider {
 
       const cmd: string = [
         Config.getGoExecutable(),
-        `get`,
-        `-u`,
-        `"${GOMANIFEST_PKG}"`,
+        `install`,
+        `github.com/fabric8-analytics/cli-tools/gomanifest@latest`,
         `&&`,
-        Config.getGoExecutable(),
-        `run`,
-        `"${GOMANIFEST_PKG}"`,
+        `gomanifest`,
         `"${vscodeRootpath}"`,
         `"${goGraphFilePath}"`,
         `"${Config.getGoExecutable()}"`,


### PR DESCRIPTION
fix dependency analysis report for Golang manifest,
using `go get` to install modules as executables was deprecated in go 1.17, `go install` should be used instead.
reference: https://go.dev/doc/go-get-install-deprecation