### PR TITLE
feat: Use codicon for vulnerability report action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/mocha": "^5.2.0",
         "@types/node": "^12.12.0",
         "@types/sinon": "^7.5.0",
-        "@types/vscode": "^1.50.0",
+        "@types/vscode": "^1.61.0",
         "chai": "^4.1.2",
         "decache": "^4.4.0",
         "glob": "^7.1.3",
@@ -42,7 +42,7 @@
         "webpack-cli": "^3.3.12"
       },
       "engines": {
-        "vscode": "^1.50.0"
+        "vscode": "^1.61.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -185,9 +185,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
+      "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -8152,9 +8152,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
+      "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
       "dev": true
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "icon": "icon/trusted_content_icon.png",
   "engines": {
-    "vscode": "^1.50.0"
+    "vscode": "^1.61.0"
   },
   "activationEvents": [
     "onCommand:fabric8.stackAnalysis",
@@ -60,10 +60,7 @@
       {
         "command": "fabric8.stackAnalysisFromPieBtn",
         "title": "Open Vulnerability Report",
-        "icon": {
-          "light": "icon/report-icon.png",
-          "dark": "icon/report-icon.png"
-        }
+        "icon": "$(pie-chart)"
       },
       {
         "command": "fabric8.stackAnalysisFromEditor",
@@ -242,7 +239,7 @@
     "@types/mocha": "^5.2.0",
     "@types/node": "^12.12.0",
     "@types/sinon": "^7.5.0",
-    "@types/vscode": "^1.50.0",
+    "@types/vscode": "^1.61.0",
     "chai": "^4.1.2",
     "decache": "^4.4.0",
     "glob": "^7.1.3",

--- a/test/vscontext.mock.ts
+++ b/test/vscontext.mock.ts
@@ -1,8 +1,9 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 let dummyMomentoData = {};
 
 class DummyMemento implements vscode.Memento {
+  keys: () => ReadonlyArray<string>;
   get<T>(key: string): Promise<T | undefined> {
     return dummyMomentoData[key];
   }
@@ -16,23 +17,23 @@ class DummyMemento implements vscode.Memento {
 }
 
 export const context: vscode.ExtensionContext = {
-  extensionPath: 'path',
-  storagePath: 'string',
-  logPath: 'string',
+  extensionPath: "path",
+  storagePath: "string",
+  logPath: "string",
   // tslint:disable-next-line:no-empty
-  subscriptions: { dispose(): any { } }[0],
+  subscriptions: { dispose(): any {} }[0],
   workspaceState: new DummyMemento(),
   globalState: new DummyMemento(),
-  globalStoragePath: 'path',
+  globalStoragePath: "path",
   asAbsolutePath(relativePath: string): string {
-    return '';
+    return "";
   },
-  extensionUri: vscode.Uri.file(''),
+  extensionUri: vscode.Uri.file(""),
   environmentVariableCollection: null,
   extensionMode: vscode.ExtensionMode.Test,
   storageUri: undefined,
   logUri: undefined,
-  globalStorageUri: undefined
+  globalStorageUri: undefined,
+  secrets: undefined,
+  extension: undefined,
 };
-
-

--- a/test/vscontext.mock.ts
+++ b/test/vscontext.mock.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import * as vscode from 'vscode';
 
 let dummyMomentoData = {};
 
@@ -17,18 +17,18 @@ class DummyMemento implements vscode.Memento {
 }
 
 export const context: vscode.ExtensionContext = {
-  extensionPath: "path",
-  storagePath: "string",
-  logPath: "string",
+  extensionPath: 'path',
+  storagePath: 'string',
+  logPath: 'string',
   // tslint:disable-next-line:no-empty
   subscriptions: { dispose(): any {} }[0],
   workspaceState: new DummyMemento(),
   globalState: new DummyMemento(),
-  globalStoragePath: "path",
+  globalStoragePath: 'path',
   asAbsolutePath(relativePath: string): string {
-    return "";
+    return '';
   },
-  extensionUri: vscode.Uri.file(""),
+  extensionUri: vscode.Uri.file(''),
   environmentVariableCollection: null,
   extensionMode: vscode.ExtensionMode.Test,
   storageUri: undefined,


### PR DESCRIPTION
Fix a bug where the "vulnerability report" menu icon does not appear correctly.
Using a codicon implies the native `vscode-codicons` support which means `^1.61.0`.

## Screenshot

![image](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/assets/114668551/d426c875-057c-4f9a-9a71-63c2b87bcaad)
