### PR TITLE
revert: fix maven executable path setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
           "description": "Path to a local file where the Red Hat Dependency Analytics report will be saved.",
           "scope": "window"
         },
-        "mvn.executable.path": {
+        "maven.executable.path": {
           "type": "string",
           "default": "",
           "description": "Specifies absolute path of mvn executable.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ export function getApiConfig(): any {
 
 export function getMvnExecutable(): string {
   const mvnPath: string = vscode.workspace
-    .getConfiguration('mvn.executable')
+    .getConfiguration('maven.executable')
     .get<string>('path');
   return mvnPath ? mvnPath : 'mvn';
 }


### PR DESCRIPTION
Revert maven executable path setting name from `mvn.executable.path` to `maven.executable.path` as that is the setting property used by VSCode Maven extension.

Refs: #665, 6c182a4