### PR TITLE
chore: add setPythonVirtualEnvironment setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fabric8-analytics/fabric8-analytics-lsp-server": "^0.9.4-ea.2",
+        "@fabric8-analytics/fabric8-analytics-lsp-server": "^0.9.4-ea.4",
         "@redhat-developer/vscode-redhat-telemetry": "^0.7.0",
-        "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.14",
+        "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.25",
         "fs": "^0.0.1-security",
         "path": "^0.12.7",
         "vscode-languageclient": "^8.1.0"
@@ -82,11 +82,11 @@
     },
     "../fabric8-analytics-lsp-server": {
       "name": "@fabric8-analytics/fabric8-analytics-lsp-server",
-      "version": "0.9.4-ea.1",
+      "version": "0.9.4-ea.3",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.14",
+        "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.24",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "json-to-ast": "^2.1.0",
@@ -568,12 +568,12 @@
       }
     },
     "node_modules/@fabric8-analytics/fabric8-analytics-lsp-server": {
-      "version": "0.9.4-ea.2",
-      "resolved": "https://npm.pkg.github.com/download/@fabric8-analytics/fabric8-analytics-lsp-server/0.9.4-ea.2/ca0ace6cc0f37bdf19993529aa18ce9094654801",
-      "integrity": "sha512-mdIiga72ISXBzAa0XNtwWLdMOjukGHZXDPpGABvP4E3NyTdfL9wGti3mV2S9oyU5wUy3LsWZBgkLXLDYrboBfA==",
+      "version": "0.9.4-ea.4",
+      "resolved": "https://npm.pkg.github.com/download/@fabric8-analytics/fabric8-analytics-lsp-server/0.9.4-ea.4/84f85fe74cc082a0cea42663edd254335f949aa8",
+      "integrity": "sha512-efGtpV0k23Vsv9rywEikMibDsCodmdIej2MkVc3wJdpKJiJbI4TE6z7FjEhrDhakSSHIfloyTkSat60ncagyFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.14",
+        "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.24",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "json-to-ast": "^2.1.0",
@@ -950,9 +950,9 @@
       }
     },
     "node_modules/@RHEcosystemAppEng/exhort-javascript-api": {
-      "version": "0.1.1-ea.14",
-      "resolved": "https://npm.pkg.github.com/download/@RHEcosystemAppEng/exhort-javascript-api/0.1.1-ea.14/b7f01baf0e01d8d697a2b5264e4f374d001004fd",
-      "integrity": "sha512-B0bnokCaz37eS3dIQPuPuwrAGU/y3TM4DT8u7xMMN9hjK9kSOq4UsWPgkJIaYstUzChgomQnXTRQhd2kNfvIIw==",
+      "version": "0.1.1-ea.25",
+      "resolved": "https://npm.pkg.github.com/download/@RHEcosystemAppEng/exhort-javascript-api/0.1.1-ea.25/dc0203a98eaa207077dd60bac09b3a3e92aa040c",
+      "integrity": "sha512-rnS1lt2pGs3dw/tECw8Z1J8IrQMuLt4GXexeiwDUThURdkEa+f9k9QU+YO8fB078SVfJarufQAO0wEMdXI5DcA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -245,6 +245,12 @@
           "default": "Error",
           "description": "Defines the severity level of alerts for detected vulnerabilities in dependencies.",
           "scope": "window"
+        },
+        "redHatDependencyAnalytics.setPythonVirtualEnvironment": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automates the installation of missing packages in a Python virtual environment when set to true.",
+          "scope": "window"
         }
       }
     }
@@ -287,9 +293,9 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@fabric8-analytics/fabric8-analytics-lsp-server": "^0.9.4-ea.2",
+    "@fabric8-analytics/fabric8-analytics-lsp-server": "^0.9.4-ea.4",
     "@redhat-developer/vscode-redhat-telemetry": "^0.7.0",
-    "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.14",
+    "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.25",
     "fs": "^0.0.1-security",
     "path": "^0.12.7",
     "vscode-languageclient": "^8.1.0"

--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { applySettingNameMappings } from './utils';
+
 /**
  * Interface representing the data structure for a Component Analysis (CA) Notification.
  */
@@ -35,7 +37,7 @@ class CANotification {
    * @param respData The data used to create the notification.
    */
   constructor(respData: CANotificationData) {
-    this.errorMessage = respData.errorMessage || '';
+    this.errorMessage = applySettingNameMappings(respData.errorMessage || '');
     this.done = respData.done === true;
     this.uri = respData.uri;
     this.diagCount = respData.diagCount || 0;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ class Config {
   rhRepositoryRecommendationNotificationCommand: string;
   utmSource: string;
   matchManifestVersions: string;
+  setPythonVirtualEnvironment: string;
   vulnerabilityAlertSeverity: string;
   exhortMvnPath: string;
   exhortNpmPath: string;
@@ -62,6 +63,8 @@ class Config {
     this.utmSource = GlobalState.UTM_SOURCE;
     /* istanbul ignore next */
     this.matchManifestVersions = rhdaConfig.matchManifestVersions ? 'true' : 'false';
+    /* istanbul ignore next */
+    this.setPythonVirtualEnvironment = rhdaConfig.setPythonVirtualEnvironment ? 'true' : 'false';
     this.vulnerabilityAlertSeverity = rhdaConfig.vulnerabilityAlertSeverity;
     /* istanbul ignore next */
     this.rhdaReportFilePath = rhdaConfig.reportFilePath || DEFAULT_RHDA_REPORT_FILE_PATH;
@@ -83,6 +86,7 @@ class Config {
     process.env['VSCEXT_REDHAT_REPOSITORY_RECOMMENDATION_NOTIFICATION_COMMAND'] = this.rhRepositoryRecommendationNotificationCommand;
     process.env['VSCEXT_UTM_SOURCE'] = this.utmSource;
     process.env['VSCEXT_MATCH_MANIFEST_VERSIONS'] = this.matchManifestVersions;
+    process.env['VSCEXT_SET_PYTHON_VIRTUAL_ENVIRONMENT'] = this.setPythonVirtualEnvironment;
     process.env['VSCEXT_VULNERABILITY_ALERT_SEVERITY'] = this.vulnerabilityAlertSeverity;
     process.env['VSCEXT_EXHORT_MVN_PATH'] = this.exhortMvnPath;
     process.env['VSCEXT_EXHORT_NPM_PATH'] = this.exhortNpmPath;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,10 @@ export enum Titles {
   REPORT_TITLE = `Red Hat Dependency Analytics Report`,
 }
 
+export const settingNameMappings: { [key: string]: string } = {
+  'EXHORT_PYTHON_VIRTUAL_ENV': 'Set Python Virtual Environment'
+};
+
 // Refer `name` from package.json
 export const EXTENSION_ID = 'fabric8-analytics';
 // publisher.name from package.json

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { CANotification } from './caNotification';
 import { DepOutputChannel } from './depOutputChannel';
 import { record, startUp, TelemetryActions } from './redhatTelemetry';
 import { validateSnykToken } from './tokenValidation';
+import { applySettingNameMappings } from './utils';
 
 let lspClient: LanguageClient;
 
@@ -45,8 +46,9 @@ export function activate(context: vscode.ExtensionContext) {
         await generateRHDAReport(context, fileUri);
         record(context, TelemetryActions.vulnerabilityReportDone, { manifest: path.basename(fileUri.fsPath), fileName: path.basename(fileUri.fsPath) });
       } catch (error) {
-        vscode.window.showErrorMessage(error.message);
-        record(context, TelemetryActions.vulnerabilityReportFailed, { manifest: path.basename(fileUri.fsPath), fileName: path.basename(fileUri.fsPath), error: error.message });
+        const message = applySettingNameMappings(error.message);
+        vscode.window.showErrorMessage(message);
+        record(context, TelemetryActions.vulnerabilityReportFailed, { manifest: path.basename(fileUri.fsPath), fileName: path.basename(fileUri.fsPath), error: message });
       }
     }
   );
@@ -251,8 +253,9 @@ function registerStackAnalysisCommands(context: vscode.ExtensionContext) {
       await generateRHDAReport(context, uri);
       record(context, TelemetryActions.vulnerabilityReportDone, { manifest: path.basename(uri.fsPath), fileName: path.basename(uri.fsPath) });
     } catch (error) {
-      vscode.window.showErrorMessage(error.message);
-      record(context, TelemetryActions.vulnerabilityReportFailed, { manifest: path.basename(uri.fsPath), fileName: path.basename(uri.fsPath), error: error.message });
+      const message = applySettingNameMappings(error.message);
+      vscode.window.showErrorMessage(message);
+      record(context, TelemetryActions.vulnerabilityReportFailed, { manifest: path.basename(uri.fsPath), fileName: path.basename(uri.fsPath), error: message });
     }
   };
 

--- a/src/stackAnalysis.ts
+++ b/src/stackAnalysis.ts
@@ -69,6 +69,7 @@ async function executeStackAnalysis(manifestFilePath): Promise<string> {
           'RHDA_TOKEN': globalConfig.telemetryId,
           'RHDA_SOURCE': globalConfig.utmSource,
           'MATCH_MANIFEST_VERSIONS': globalConfig.matchManifestVersions,
+          'EXHORT_PYTHON_VIRTUAL_ENV': globalConfig.setPythonVirtualEnvironment,
           'EXHORT_MVN_PATH': globalConfig.exhortMvnPath,
           'EXHORT_NPM_PATH': globalConfig.exhortNpmPath,
           'EXHORT_GO_PATH': globalConfig.exhortGoPath,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,14 @@
+'use strict';
+
+import { settingNameMappings } from './constants';
+
+export function applySettingNameMappings(message: string): string {
+    let modifiedMessage = message;
+
+    Object.keys(settingNameMappings).forEach(key => {
+        const regex = new RegExp(key, 'g');
+        modifiedMessage = modifiedMessage.replace(regex, settingNameMappings[key]);
+    });
+
+    return modifiedMessage;
+}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -33,6 +33,7 @@ suite('Config module', () => {
     expect(globalConfig.rhRepositoryRecommendationNotificationCommand).to.eq(commands.REDHAT_REPOSITORY_RECOMMENDATION_NOTIFICATION_COMMAND);
     expect(globalConfig.utmSource).to.eq(GlobalState.UTM_SOURCE);
     expect(globalConfig.matchManifestVersions).to.eq('true');
+    expect(globalConfig.setPythonVirtualEnvironment).to.eq('false');
     expect(globalConfig.vulnerabilityAlertSeverity).to.eq('Error');
     expect(globalConfig.rhdaReportFilePath).to.eq('/tmp/redhatDependencyAnalyticsReport.html');
     expect(globalConfig.exhortMvnPath).to.eq('mvn');

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,53 @@
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+
+import { settingNameMappings } from '../src/constants';
+import { applySettingNameMappings } from '../src/utils';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+suite('Utils module', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('should return a string with applied mappings', () => {
+
+        Object.keys(settingNameMappings).forEach(key => {
+            const message = `The ${key} variable should be set.`;
+            const expectedMessage = `The ${settingNameMappings[key]} variable should be set.`;
+
+            const result = applySettingNameMappings(message);
+
+            expect(result).to.equal(expectedMessage);
+        });
+    });
+
+    test('should handle multiple occurrences of mapping keys', () => {
+
+        Object.keys(settingNameMappings).forEach(key => {
+            const message = `Please ensure the ${key} is properly configured. Set ${key} to true.`;
+            const expectedMessage = `Please ensure the ${settingNameMappings[key]} is properly configured. Set ${settingNameMappings[key]} to true.`;
+
+            const result = applySettingNameMappings(message);
+
+            expect(result).to.equal(expectedMessage);
+        });
+    });
+
+    test('should not modify the message if no mappings apply', () => {
+        const message = 'This message does not contain any mapping keys.';
+
+        const result = applySettingNameMappings(message);
+
+        expect(result).to.equal(message);
+    });
+});


### PR DESCRIPTION
An extension setting, 'setPythonVirtualEnvironment', has been introduced to support the EXHORT_PYTHON_VIRTUAL_ENV environment variable for JavaScript APIs.