### PR TITLE
docs: Updates to the readme and changelog for Gradle feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 ## 0.9.5 (?)
+- enhancement - Added support for vulnerability analysis for Gradle build manifests.
 - enhancement - Added support for vulnerability analysis on images in Dockerfiles.
 - enhancement - Added new settings for the Python and Go ecosystems.
 - enhancement - Added support for private GitHub Registries.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In future releases, Red Hat plans to support other programming languages.
 - For Node projects, analyzing a `package.json` file, you must have the `npm` binary in your system’s `PATH` environment.
 - For Golang projects, analyzing a `go.mod` file, you must have the `go` binary in your system’s `PATH` environment.
 - For Python projects, analyzing a `requirements.txt` file, you must have the `python3/pip3` or `python/pip` binaries in your system’s `PATH` environment.
+- For Gradle projects, analyzing a `build.gradle` file, you must have the `gradle` binary in your system's `PATH` environment.
 - For base images in a `Dockerfile`.
 
 <br >**IMPORTANT:** 


### PR DESCRIPTION
Updates to the `README.md` and `CHANGELOG.md` files for the additional support for Gradle build manifests.