### PR TITLE
feat: support configuring maven wrapper usage preference

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,6 +215,12 @@
           "description": "Specifies absolute path of mvn executable.",
           "scope": "window"
         },
+        "redHatDependencyAnalytics.mvn.preferWrapper": {
+          "type": "string",
+          "enum": ["true", "false", "fallback"],
+          "default": "fallback",
+          "markdownDescription": "Specifies whether to use the local maven wrapper. The 'fallback' option will default to the value of `#maven.executable.preferMavenWrapper#` from the `Maven for Java` extension, else defaulting to 'true'."
+        },
         "redHatDependencyAnalytics.gradle.executable.path": {
           "type": "string",
           "default": "",

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ class Config {
   usePipDepTree: string;
   vulnerabilityAlertSeverity: string;
   exhortMvnPath: string;
+  exhortPreferMvnw: string;
   exhortGradlePath: string;
   exhortNpmPath: string;
   exhortGoPath: string;
@@ -74,6 +75,10 @@ class Config {
   loadData() {
     const rhdaConfig = this.getRhdaConfig();
 
+    const rhdaPreferMavenWrapper = vscode.workspace.getConfiguration('redHatDependencyAnalytics.mvn').get('preferWrapper') as 'true' | 'false' | 'fallback';
+    const msftPreferMavenWrapper = vscode.workspace.getConfiguration('maven.executable').get('preferMavenWrapper', true);
+    const preferMavenWrapper = rhdaPreferMavenWrapper === 'fallback' ? msftPreferMavenWrapper : rhdaPreferMavenWrapper === 'true';
+
     this.stackAnalysisCommand = commands.STACK_ANALYSIS_COMMAND;
     this.trackRecommendationAcceptanceCommand = commands.TRACK_RECOMMENDATION_ACCEPTANCE_COMMAND;
     this.utmSource = GlobalState.UTM_SOURCE;
@@ -91,6 +96,7 @@ class Config {
     /* istanbul ignore next */
     this.rhdaReportFilePath = rhdaConfig.reportFilePath || DEFAULT_RHDA_REPORT_FILE_PATH;
     this.exhortMvnPath = rhdaConfig.mvn.executable.path || this.DEFAULT_MVN_EXECUTABLE;
+    this.exhortPreferMvnw = preferMavenWrapper.toString();
     this.exhortGradlePath = rhdaConfig.gradle.executable.path || this.DEFAULT_GRADLE_EXECUTABLE;
     this.exhortNpmPath = rhdaConfig.npm.executable.path || this.DEFAULT_NPM_EXECUTABLE;
     this.exhortGoPath = rhdaConfig.go.executable.path || this.DEFAULT_GO_EXECUTABLE;
@@ -122,6 +128,7 @@ class Config {
     process.env['VSCEXT_USE_PIP_DEP_TREE'] = this.usePipDepTree;
     process.env['VSCEXT_VULNERABILITY_ALERT_SEVERITY'] = this.vulnerabilityAlertSeverity;
     process.env['VSCEXT_EXHORT_MVN_PATH'] = this.exhortMvnPath;
+    process.env['VSCEXT_EXHORT_PREFER_MVNW'] = this.exhortPreferMvnw;
     process.env['VSCEXT_EXHORT_GRADLE_PATH'] = this.exhortGradlePath;
     process.env['VSCEXT_EXHORT_NPM_PATH'] = this.exhortNpmPath;
     process.env['VSCEXT_EXHORT_GO_PATH'] = this.exhortGoPath;

--- a/src/stackAnalysis.ts
+++ b/src/stackAnalysis.ts
@@ -13,7 +13,7 @@ import { updateCurrentWebviewPanel } from './rhda';
  * @param manifestFilePath The file path to the manifest file for analysis.
  * @returns The stack analysis response string.
  */
-export async function executeStackAnalysis(manifestFilePath): Promise<string> {
+export async function executeStackAnalysis(manifestFilePath: string): Promise<string> {
   try {
     return await vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: Titles.EXT_TITLE }, async p => {
       return new Promise<string>(async (resolve, reject) => {
@@ -31,6 +31,7 @@ export async function executeStackAnalysis(manifestFilePath): Promise<string> {
           'EXHORT_PYTHON_INSTALL_BEST_EFFORTS': globalConfig.enablePythonBestEffortsInstallation,
           'EXHORT_PIP_USE_DEP_TREE': globalConfig.usePipDepTree,
           'EXHORT_MVN_PATH': globalConfig.exhortMvnPath,
+          'EXHORT_PREFER_MVNW': globalConfig.exhortPreferMvnw,
           'EXHORT_GRADLE_PATH': globalConfig.exhortGradlePath,
           'EXHORT_NPM_PATH': globalConfig.exhortNpmPath,
           'EXHORT_GO_PATH': globalConfig.exhortGoPath,


### PR DESCRIPTION
Related: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/541

Introduces a new configuration setting with three values: true, false & fallback. If fallback is set, the preference will be derived from the similarly named setting from the [Maven for Java](https://marketplace.visualstudio.com/items/?itemName=vscjava.vscode-maven) MSFT extension.

