### PR TITLE
chore: refactor usage of promises into async/await

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,8 +36,8 @@
         ],
         "background": {
           "activeOnStart": true,
-          "beginsPattern": "Compilation \\w+ starting…",
-          "endsPattern": "Compilation\\s+finished"
+          "beginsPattern": "assets by status",
+          "endsPattern": "compiled successfully in"
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fabric8-analytics/fabric8-analytics-lsp-server": "^0.9.4-ea.28",
         "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
-        "@trustification/exhort-javascript-api": "^0.1.1-ea.54",
+        "@trustification/exhort-javascript-api": "^0.1.1-ea.62",
         "fs": "^0.0.1-security",
         "path": "^0.12.7",
         "vscode-languageclient": "^8.1.0"
@@ -910,9 +910,9 @@
       "dev": true
     },
     "node_modules/@trustification/exhort-javascript-api": {
-      "version": "0.1.1-ea.54",
-      "resolved": "https://npm.pkg.github.com/download/@trustification/exhort-javascript-api/0.1.1-ea.54/aae647f54b19514204c3dd98d554ae4513350d4e",
-      "integrity": "sha512-rep69WMzo7s8PUxuPCgnExe3cvBFxpGj1qMpBGzpUcbzBuLsDTr2YbbExpALzhtsnO05LfowInp1FERTEeX8nQ==",
+      "version": "0.1.1-ea.62",
+      "resolved": "https://npm.pkg.github.com/download/@trustification/exhort-javascript-api/0.1.1-ea.62/7fb821648ea3f6342c6137bd89ed9e94c550138f",
+      "integrity": "sha512-wvZWneHLkzYaf8BewySHmhBCmLz33nYX/Y1bXIoWXrHsZ4DwxhovJeWQXodJkx/KbwbGWYFS7OvQkEggP4+aug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -385,7 +385,7 @@
   "dependencies": {
     "@fabric8-analytics/fabric8-analytics-lsp-server": "^0.9.4-ea.28",
     "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
-    "@trustification/exhort-javascript-api": "^0.1.1-ea.54",
+    "@trustification/exhort-javascript-api": "^0.1.1-ea.62",
     "fs": "^0.0.1-security",
     "path": "^0.12.7",
     "vscode-languageclient": "^8.1.0"

--- a/src/config.ts
+++ b/src/config.ts
@@ -153,7 +153,7 @@ class Config {
    * Authorizes the RHDA (Red Hat Dependency Analytics) service.
    * @param context The extension context for authorization.
    */
-  async authorizeRHDA(context): Promise<void> {
+  async authorizeRHDA(context: vscode.ExtensionContext): Promise<void> {
     this.telemetryId = await getTelemetryId(context);
     await this.setProcessEnv();
   }
@@ -214,7 +214,6 @@ class Config {
       } else {
         console.error(errorMsg);
       }
-
     }
   }
 }

--- a/src/exhortServices.ts
+++ b/src/exhortServices.ts
@@ -59,19 +59,20 @@ async function tokenValidationService(options: object, source: string): Promise<
     // Get token validation status code
     const tokenValidationStatus = await exhort.validateToken(options);
 
-    if (tokenValidationStatus === 200) {
-      vscode.window.showInformationMessage(`${source} token validated successfully`);
-      return;
-    } else if (tokenValidationStatus === 400) {
-      return `Missing token. Please provide a valid ${source} Token in the extension workspace settings. Status: ${tokenValidationStatus}`;
-    } else if (tokenValidationStatus === 401) {
-      return `Invalid token. Please provide a valid ${source} Token in the extension workspace settings. Status: ${tokenValidationStatus}`;
-    } else if (tokenValidationStatus === 403) {
-      return `Forbidden. The token does not have permissions. Please provide a valid ${source} Token in the extension workspace settings. Status: ${tokenValidationStatus}`;
-    } else if (tokenValidationStatus === 429) {
-      return `Too many requests. Rate limit exceeded. Please try again in a little while. Status: ${tokenValidationStatus}`;
-    } else {
-      return `Failed to validate token. Status: ${tokenValidationStatus}`;
+    switch (tokenValidationStatus) {
+      case 200:
+        vscode.window.showInformationMessage(`${source} token validated successfully`);
+        return;
+      case 400:
+        return `Missing token. Please provide a valid ${source} Token in the extension workspace settings. Status: ${tokenValidationStatus}`;
+      case 401:
+        return `Invalid token. Please provide a valid ${source} Token in the extension workspace settings. Status: ${tokenValidationStatus}`;
+      case 403:
+        return `Forbidden. The token does not have permissions. Please provide a valid ${source} Token in the extension workspace settings. Status: ${tokenValidationStatus}`;
+      case 429:
+        return `Too many requests. Rate limit exceeded. Please try again in a little while. Status: ${tokenValidationStatus}`;
+      default:
+        return `Failed to validate token. Status: ${tokenValidationStatus}`;
     }
   } catch (error) {
     return `Failed to validate token, Error: ${error.message}`;

--- a/src/exhortServices.ts
+++ b/src/exhortServices.ts
@@ -12,36 +12,29 @@ import { IImageRef, IOptions } from './imageAnalysis';
  * @param options - The options for running image analysis.
  * @returns A Promise resolving to the analysis response in HTML format.
  */
-function imageAnalysisService(images: IImageRef[], options: IOptions): Promise<any> {
-  return new Promise<any>(async (resolve, reject) => {
-    const jarPath = `${__dirname}/../javaApiAdapter/exhort-java-api-adapter-1.0-SNAPSHOT-jar-with-dependencies.jar`;
-    const reportType = 'html';
-    let parameters = '';
-    let properties = '';
+async function imageAnalysisService(images: IImageRef[], options: IOptions): Promise<any> {
+  const jarPath = `${__dirname}/../javaApiAdapter/exhort-java-api-adapter-1.0-SNAPSHOT-jar-with-dependencies.jar`;
+  const reportType = 'html';
+  let parameters = '';
+  let properties = '';
 
-    images.forEach(image => {
-      if (image.platform) {
-        parameters += ` ${image.image}^^${image.platform}`;
-      } else {
-        parameters += ` ${image.image}`;
-      }
-    });
-
-    for (const setting in options) {
-      if (options[setting]) {
-        properties += ` -D${setting}=${options[setting]}`;
-      }
-    }
-
-    try {
-      const result = execSync(`java${properties} -jar ${jarPath} ${reportType}${parameters}`, {
-        maxBuffer: 1000 * 1000 * 10, // 10 MB
-      });
-      resolve(result.toString());
-    } catch (error) {
-      reject(error);
+  images.forEach(image => {
+    if (image.platform) {
+      parameters += ` ${image.image}^^${image.platform}`;
+    } else {
+      parameters += ` ${image.image}`;
     }
   });
+
+  for (const setting in options) {
+    if (options[setting]) {
+      properties += ` -D${setting}=${options[setting]}`;
+    }
+  }
+
+  return execSync(`java${properties} -jar ${jarPath} ${reportType}${parameters}`, {
+    maxBuffer: 1000 * 1000 * 10, // 10 MB
+  }).toString();
 }
 
 /**
@@ -50,16 +43,9 @@ function imageAnalysisService(images: IImageRef[], options: IOptions): Promise<a
  * @param options Additional options for the analysis.
  * @returns A promise resolving to the stack analysis report in HTML format.
  */
-function stackAnalysisService(pathToManifest: string, options: object): Promise<any> {
-  return new Promise<any>(async (resolve, reject) => {
-    try {
-      // Get stack analysis in HTML format
-      const stackAnalysisReportHtml = await exhort.stackAnalysis(pathToManifest, true, options);
-      resolve(stackAnalysisReportHtml);
-    } catch (error) {
-      reject(error);
-    }
-  });
+async function stackAnalysisService(pathToManifest: string, options: object): Promise<string> {
+  // Get stack analysis in HTML format
+  return await exhort.stackAnalysis(pathToManifest, true, options);
 }
 
 /**
@@ -68,32 +54,21 @@ function stackAnalysisService(pathToManifest: string, options: object): Promise<
  * @param source The source for which the token is being validated.
  * @returns A promise resolving after validating the token.
  */
-async function tokenValidationService(options, source): Promise<string> {
+async function tokenValidationService(options: object, source: string): Promise<string | undefined> {
   try {
-
     // Get token validation status code
     const tokenValidationStatus = await exhort.validateToken(options);
 
-    if (
-      tokenValidationStatus === 200
-    ) {
+    if (tokenValidationStatus === 200) {
       vscode.window.showInformationMessage(`${source} token validated successfully`);
       return;
-    } else if (
-      tokenValidationStatus === 400
-    ) {
+    } else if (tokenValidationStatus === 400) {
       return `Missing token. Please provide a valid ${source} Token in the extension workspace settings. Status: ${tokenValidationStatus}`;
-    } else if (
-      tokenValidationStatus === 401
-    ) {
+    } else if (tokenValidationStatus === 401) {
       return `Invalid token. Please provide a valid ${source} Token in the extension workspace settings. Status: ${tokenValidationStatus}`;
-    } else if (
-      tokenValidationStatus === 403
-    ) {
+    } else if (tokenValidationStatus === 403) {
       return `Forbidden. The token does not have permissions. Please provide a valid ${source} Token in the extension workspace settings. Status: ${tokenValidationStatus}`;
-    } else if (
-      tokenValidationStatus === 429
-    ) {
+    } else if (tokenValidationStatus === 429) {
       return `Too many requests. Rate limit exceeded. Please try again in a little while. Status: ${tokenValidationStatus}`;
     } else {
       return `Failed to validate token. Status: ${tokenValidationStatus}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,26 +81,6 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  // const disposableSetSnykToken = vscode.commands.registerCommand(
-  //   commands.SET_SNYK_TOKEN_COMMAND,
-  //   async () => {
-  //     const token = await vscode.window.showInputBox({
-  //       prompt: 'Please enter your Snyk Token:',
-  //       placeHolder: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-  //       password: true,
-  //       validateInput: validateSnykToken
-  //     });
-
-  //     if (token === undefined) {
-  //       return;
-  //     } else if (token === '') {
-  //       await globalConfig.clearSnykToken(true);
-  //     } else {
-  //       await globalConfig.setSnykToken(token);
-  //     }
-  //   }
-  // );
-
   registerStackAnalysisCommands(context);
 
   globalConfig.authorizeRHDA(context)
@@ -157,8 +137,7 @@ export function activate(context: vscode.ExtensionContext) {
           if (selection === PromptText.FULL_STACK_PROMPT_TEXT) {
             record(context, TelemetryActions.vulnerabilityReportPopupOpened, { manifest: fileName, fileName: fileName });
             vscode.commands.executeCommand(commands.STACK_ANALYSIS_COMMAND, filePath);
-          }
-          else {
+          } else {
             record(context, TelemetryActions.vulnerabilityReportPopupIgnored, { manifest: fileName, fileName: fileName });
           }
         };
@@ -194,19 +173,12 @@ export function activate(context: vscode.ExtensionContext) {
     })
     .catch(error => {
       vscode.window.showErrorMessage(`Failed to Authorize Red Hat Dependency Analytics extension: ${error.message}`);
-      throw (error);
+      throw error;
     });
 
   vscode.workspace.onDidChangeConfiguration(() => {
     globalConfig.loadData();
   });
-
-  // context.secrets.onDidChange(async (e) => {
-  //   if (e.key === SNYK_TOKEN_KEY) {
-  //     const token = await globalConfig.getSnykToken();
-  //     lspClient.sendNotification('snykTokenModified', token);
-  //   }
-  // });
 }
 
 /**
@@ -214,10 +186,7 @@ export function activate(context: vscode.ExtensionContext) {
  * @returns A `Thenable` for void.
  */
 export function deactivate(): Thenable<void> {
-  if (!lspClient) {
-    return undefined;
-  }
-  return lspClient.stop();
+  return lspClient?.stop();
 }
 
 /**
@@ -263,10 +232,10 @@ function redirectToRedHatCatalog() {
  * Shows a notification regarding Red Hat Dependency Analytics recommendations.
  */
 function showRHRepositoryRecommendationNotification() {
-  const msg = `Important: If you apply Red Hat Dependency Analytics recommendations, 
-                  make sure the Red Hat GA Repository (${REDHAT_MAVEN_REPOSITORY}) has been added to your project configuration. 
-                  This ensures that the applied dependencies work correctly. 
-                  Learn how to add the repository: [Click here](${REDHAT_MAVEN_REPOSITORY_DOCUMENTATION_URL})`;
+  const msg = 'Important: If you apply Red Hat Dependency Analytics recommendations, ' +
+    `make sure the Red Hat GA Repository (${REDHAT_MAVEN_REPOSITORY}) has been added to your project configuration. ` +
+    'This ensures that the applied dependencies work correctly. ' +
+    `Learn how to add the repository: [Click here](${REDHAT_MAVEN_REPOSITORY_DOCUMENTATION_URL})`;
   vscode.window.showWarningMessage(msg);
 }
 

--- a/src/imageAnalysis.ts
+++ b/src/imageAnalysis.ts
@@ -78,7 +78,7 @@ class DockerImageAnalysis implements IImageAnalysis {
     args: Map<string, string> = new Map<string, string>();
     images: IImageRef[] = [];
     imageAnalysisReportHtml: string = '';
-    filePath: string
+    filePath: string;
 
     /**
      * Regular expression for matching 'FROM' statements.
@@ -102,7 +102,7 @@ class DockerImageAnalysis implements IImageAnalysis {
 
     constructor(filePath: string) {
         const lines = this.parseTxtDoc(filePath);
-        this.filePath = filePath
+        this.filePath = filePath;
         this.images = this.collectImages(lines);
     }
 
@@ -184,7 +184,7 @@ class DockerImageAnalysis implements IImageAnalysis {
             try {
 
                 // execute image analysis
-                const promise = imageAnalysisService(this.images, this.options)
+                const promise = imageAnalysisService(this.images, this.options);
                 p.report({ message: StatusMessages.WIN_GENERATING_DEPENDENCIES });
 
                 const resp = await promise;
@@ -198,7 +198,7 @@ class DockerImageAnalysis implements IImageAnalysis {
 
                 updateCurrentWebviewPanel('error');
 
-                throw error
+                throw error;
             }
         });
     }

--- a/src/redhatTelemetry.ts
+++ b/src/redhatTelemetry.ts
@@ -66,7 +66,7 @@ async function startUp(context: vscode.ExtensionContext) {
  * @param context The extension context.
  * @returns A promise resolving to the telemetry ID.
  */
-async function getTelemetryId(context) {
+async function getTelemetryId(context: vscode.ExtensionContext) {
   const redhatService = await getRedHatService(context);
   const redhatIdProvider = await redhatService.getIdProvider();
   const telemetryId = await redhatIdProvider.getRedHatUUID();

--- a/src/rhda.ts
+++ b/src/rhda.ts
@@ -87,7 +87,7 @@ async function writeReportToFile(data: string) {
     fs.mkdirSync(reportDirectoryPath, { recursive: true });
   }
 
-  await fs.promises.writeFile(reportFilePath, data)
+  await fs.promises.writeFile(reportFilePath, data);
 }
 
 /**

--- a/src/stackAnalysis.ts
+++ b/src/stackAnalysis.ts
@@ -39,7 +39,7 @@ export async function executeStackAnalysis(manifestFilePath: string): Promise<st
 
     // execute stack analysis
     try {
-      const promise = stackAnalysisService(manifestFilePath, options)
+      const promise = stackAnalysisService(manifestFilePath, options);
 
       p.report({ message: StatusMessages.WIN_GENERATING_DEPENDENCIES });
 
@@ -49,7 +49,7 @@ export async function executeStackAnalysis(manifestFilePath: string): Promise<st
 
       p.report({ message: StatusMessages.WIN_SUCCESS_DEPENDENCY_ANALYSIS });
 
-      return resp
+      return resp;
     } catch (err) {
       p.report({ message: StatusMessages.WIN_FAILURE_DEPENDENCY_ANALYSIS });
 

--- a/src/stackAnalysis.ts
+++ b/src/stackAnalysis.ts
@@ -14,65 +14,48 @@ import { updateCurrentWebviewPanel } from './rhda';
  * @returns The stack analysis response string.
  */
 export async function executeStackAnalysis(manifestFilePath: string): Promise<string> {
-  try {
-    return await vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: Titles.EXT_TITLE }, async p => {
-      return new Promise<string>(async (resolve, reject) => {
-        p.report({
-          message: StatusMessages.WIN_ANALYZING_DEPENDENCIES
-        });
+  return await vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: Titles.EXT_TITLE }, async p => {
+    p.report({ message: StatusMessages.WIN_ANALYZING_DEPENDENCIES });
 
-        // set up configuration options for the stack analysis request
-        const options = {
-          'RHDA_TOKEN': globalConfig.telemetryId,
-          'RHDA_SOURCE': globalConfig.utmSource,
-          'MATCH_MANIFEST_VERSIONS': globalConfig.matchManifestVersions,
-          'EXHORT_PYTHON_VIRTUAL_ENV': globalConfig.usePythonVirtualEnvironment,
-          'EXHORT_GO_MVS_LOGIC_ENABLED': globalConfig.useGoMVS,
-          'EXHORT_PYTHON_INSTALL_BEST_EFFORTS': globalConfig.enablePythonBestEffortsInstallation,
-          'EXHORT_PIP_USE_DEP_TREE': globalConfig.usePipDepTree,
-          'EXHORT_MVN_PATH': globalConfig.exhortMvnPath,
-          'EXHORT_PREFER_MVNW': globalConfig.exhortPreferMvnw,
-          'EXHORT_GRADLE_PATH': globalConfig.exhortGradlePath,
-          'EXHORT_NPM_PATH': globalConfig.exhortNpmPath,
-          'EXHORT_GO_PATH': globalConfig.exhortGoPath,
-          'EXHORT_PYTHON3_PATH': globalConfig.exhortPython3Path,
-          'EXHORT_PIP3_PATH': globalConfig.exhortPip3Path,
-          'EXHORT_PYTHON_PATH': globalConfig.exhortPythonPath,
-          'EXHORT_PIP_PATH': globalConfig.exhortPipPath
-        };
+    // set up configuration options for the stack analysis request
+    const options = {
+      'RHDA_TOKEN': globalConfig.telemetryId,
+      'RHDA_SOURCE': globalConfig.utmSource,
+      'MATCH_MANIFEST_VERSIONS': globalConfig.matchManifestVersions,
+      'EXHORT_PYTHON_VIRTUAL_ENV': globalConfig.usePythonVirtualEnvironment,
+      'EXHORT_GO_MVS_LOGIC_ENABLED': globalConfig.useGoMVS,
+      'EXHORT_PYTHON_INSTALL_BEST_EFFORTS': globalConfig.enablePythonBestEffortsInstallation,
+      'EXHORT_PIP_USE_DEP_TREE': globalConfig.usePipDepTree,
+      'EXHORT_MVN_PATH': globalConfig.exhortMvnPath,
+      'EXHORT_PREFER_MVNW': globalConfig.exhortPreferMvnw,
+      'EXHORT_GRADLE_PATH': globalConfig.exhortGradlePath,
+      'EXHORT_NPM_PATH': globalConfig.exhortNpmPath,
+      'EXHORT_GO_PATH': globalConfig.exhortGoPath,
+      'EXHORT_PYTHON3_PATH': globalConfig.exhortPython3Path,
+      'EXHORT_PIP3_PATH': globalConfig.exhortPip3Path,
+      'EXHORT_PYTHON_PATH': globalConfig.exhortPythonPath,
+      'EXHORT_PIP_PATH': globalConfig.exhortPipPath
+    };
 
-        // const snykToken = await globalConfig.getSnykToken();
-        // /* istanbul ignore else */
-        // if (snykToken !== '') {
-        //   options['EXHORT_SNYK_TOKEN'] = snykToken;
-        // }
+    // execute stack analysis
+    try {
+      const promise = stackAnalysisService(manifestFilePath, options)
 
-        // execute stack analysis
-        await stackAnalysisService(manifestFilePath, options)
-          .then(async (resp) => {
-            p.report({
-              message: StatusMessages.WIN_GENERATING_DEPENDENCIES
-            });
+      p.report({ message: StatusMessages.WIN_GENERATING_DEPENDENCIES });
 
-            updateCurrentWebviewPanel(resp);
+      const resp = await promise;
 
-            p.report({
-              message: StatusMessages.WIN_SUCCESS_DEPENDENCY_ANALYSIS
-            });
+      updateCurrentWebviewPanel(resp);
 
-            resolve(resp);
-          })
-          .catch(err => {
-            p.report({
-              message: StatusMessages.WIN_FAILURE_DEPENDENCY_ANALYSIS
-            });
+      p.report({ message: StatusMessages.WIN_SUCCESS_DEPENDENCY_ANALYSIS });
 
-            reject(err);
-          });
-      });
-    });
-  } catch (err) {
-    updateCurrentWebviewPanel('error');
-    throw (err);
-  }
+      return resp
+    } catch (err) {
+      p.report({ message: StatusMessages.WIN_FAILURE_DEPENDENCY_ANALYSIS });
+
+      updateCurrentWebviewPanel('error');
+
+      throw err;
+    }
+  });
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -265,23 +265,24 @@ export const LOADER_TEMPLATE = `<!DOCTYPE html>
 export const ERROR_TEMPLATE = `<!DOCTYPE html>
     <html lang="en">
     <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
-    html,body {
-    width: 99%;
-    height: 99%;
-    font-size: 16px;
-    }
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <style>
+        html,body {
+            width: 99%;
+            height: 99%;
+            font-size: 16px;
+        }
 
-    body {
-    background: #ffffff;
-    }
+        body {
+            background: #ffffff;
+        }
 
-    </style>
+        </style>
     </head>
     <body>
-    <div>
-    <p style='color:#000000;text-align: center;'>Unable to analyze your stack.</p>
-    </div>
-    </body></html>`;
+        <div>
+            <p style='color:#000000;text-align: center;'>Unable to analyze your stack.</p>
+        </div>
+    </body>
+    </html>`;

--- a/test/rhda.test.ts
+++ b/test/rhda.test.ts
@@ -42,7 +42,7 @@ suite('RHDA module', () => {
         sandbox.restore();
     });
 
-    test('should ignore unsoported file', async () => {
+    test('should ignore unsupported file', async () => {
         const unsupportedFilePath = mockInvalidPath;
         const authorizeRHDAStub = sandbox.stub(globalConfig, 'authorizeRHDA').resolves();
         const stackAnalysisServiceStub = sandbox.stub(stackAnalysis, 'executeStackAnalysis').resolves(mockReponse)
@@ -54,7 +54,7 @@ suite('RHDA module', () => {
         expect(authorizeRHDAStub.calledOnce).to.be.false;
         expect(stackAnalysisServiceStub.calledOnce).to.be.false;
         expect(imageAnalysisServiceStub.calledOnce).to.be.false;
-        expect(showInformationMessageSpy.calledOnceWith(`File ${unsupportedFilePath} is not supported!!`)).to.be.true;
+        expect(showInformationMessageSpy.calledOnceWith(`File ${unsupportedFilePath} is not supported.`)).to.be.true;
     });
 
     test('should receive RHDA report for supported dependency file and successfully save HTML data locally', async () => {

--- a/test/rhda.test.ts
+++ b/test/rhda.test.ts
@@ -60,9 +60,7 @@ suite('RHDA module', () => {
     test('should receive RHDA report for supported dependency file and successfully save HTML data locally', async () => {
         const authorizeRHDAStub = sandbox.stub(globalConfig, 'authorizeRHDA').resolves();
         const stackAnalysisServiceStub = sandbox.stub(stackAnalysis, 'executeStackAnalysis').resolves(mockReponse)
-        const writeFileStub = sandbox.stub(fs, 'writeFile').callsFake((path, data, callback) => {
-            callback(null);
-        });
+        const writeFileStub = sandbox.stub(fs.promises, 'writeFile').resolves(null)
 
         await rhda.generateRHDAReport(context, mockGoPath);
 
@@ -74,9 +72,7 @@ suite('RHDA module', () => {
     test('should receive RHDA report for supported image file and successfully save HTML data locally', async () => {
         const authorizeRHDAStub = sandbox.stub(globalConfig, 'authorizeRHDA').resolves();
         const imageAnalysisServiceStub = sandbox.stub(imageAnalysis, 'executeDockerImageAnalysis').resolves(mockReponse)
-        const writeFileStub = sandbox.stub(fs, 'writeFile').callsFake((path, data, callback) => {
-            callback(null);
-        });
+        const writeFileStub = sandbox.stub(fs.promises, 'writeFile').resolves(null)
 
         await rhda.generateRHDAReport(context, mockDockerfilePath);
 
@@ -118,9 +114,7 @@ suite('RHDA module', () => {
     test('should generate RHDA report for supported file successfully but fail to save HTML locally', async () => {
         const authorizeRHDAStub = sandbox.stub(globalConfig, 'authorizeRHDA').resolves();
         const stackAnalysisServiceStub = sandbox.stub(stackAnalysis, 'executeStackAnalysis').resolves(mockReponse)
-        const writeFileStub = sandbox.stub(fs, 'writeFile').callsFake((path, data, callback) => {
-            callback(new Error('Mock Error'));
-        });
+        const writeFileStub = sandbox.stub(fs.promises, 'writeFile').throws(new Error('Mock Error'))
 
         await rhda.generateRHDAReport(context, mockNpmPath)
             .then(() => {
@@ -156,9 +150,7 @@ suite('RHDA module', () => {
     test('should trigger and update webview panel', async () => {
         const authorizeRHDAStub = sandbox.stub(globalConfig, 'authorizeRHDA').resolves();
         const stackAnalysisServiceStub = sandbox.stub(stackAnalysis, 'executeStackAnalysis').resolves(mockReponse)
-        const writeFileStub = sandbox.stub(fs, 'writeFile').callsFake((path, data, callback) => {
-            callback(null);
-        });
+        const writeFileStub = sandbox.stub(fs.promises, 'writeFile').resolves(null)
 
         await rhda.generateRHDAReport(context, mockGradlePath);
 


### PR DESCRIPTION
Removes extraneous `try { } catch(e) { throw e }`, unwraps usage of `new Promise` wrapped by try catch into direct async-awaits, and some other minor formatting changes/multiline string usage/missing parameter types.