### PR TITLE
fix: add JSONC listening for when package.json has jsonc file association

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,6 +110,7 @@ export function activate(context: vscode.ExtensionContext) {
       const clientOptions: LanguageClientOptions = {
         documentSelector: [
           { scheme: 'file', language: 'json' },
+          { scheme: 'file', language: 'jsonc' },
           { scheme: 'file', language: 'xml' },
           { scheme: 'file', language: 'plaintext' },
           { scheme: 'file', language: 'pip-requirements' },


### PR DESCRIPTION
File diagnostics for package.json won't be triggered if the user has package.json files associated with `jsonc` language ID instead of `json`. Fixed by having the LSP also receive events for jsonc files

Fix #760