### PR TITLE
feat: include logging the invoking & erroring of generating RHDA reports

### DIFF
--- a/src/depOutputChannel.ts
+++ b/src/depOutputChannel.ts
@@ -18,34 +18,26 @@ export class DepOutputChannel {
   }
 
   /**
-   * Retrieves the VS Code OutputChannel instance.
-   * Clears the channel before returning.
-   * @returns The VS Code OutputChannel instance.
-   */
-  getOutputChannel(): vscode.OutputChannel {
-    this.outputChannel.clear();
-    return this.outputChannel;
-  }
-
-  /**
    * Shows the output channel in the VS Code UI.
    */
-  showOutputChannel(): void {
+  show(): void {
     this.outputChannel.show();
   }
 
   /**
    * Clears the content of the output channel.
    */
-  clearOutputChannel(): void {
+  clear(): void {
     this.outputChannel.clear();
   }
 
-  /**
-   * Appends a message to the output channel.
-   * @param msg The message to append to the output channel.
-   */
-  addMsgOutputChannel(msg: string): void {
-    this.outputChannel.append(msg);
+  debug(msg: string) { this.write('DEBUG', msg); }
+  info(msg: string) { this.write('INFO', msg); }
+  warn(msg: string) { this.write('WARN', msg); }
+  error(msg: string) { this.write('ERROR', msg); }
+
+  private write(label: string, msg: string): void {
+    const datetime = new Date().toLocaleString();
+    this.outputChannel.appendLine(`${label} ${datetime}: ${msg}`);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,8 +18,7 @@ import { caStatusBarProvider } from './caStatusBarProvider';
 import { CANotification } from './caNotification';
 import { DepOutputChannel } from './depOutputChannel';
 import { record, startUp, TelemetryActions } from './redhatTelemetry';
-// import { validateSnykToken } from './tokenValidation';
-import { applySettingNameMappings } from './utils';
+import { applySettingNameMappings, buildErrorMessage } from './utils';
 
 let lspClient: LanguageClient;
 
@@ -51,6 +50,7 @@ export function activate(context: vscode.ExtensionContext) {
       } catch (error) {
         const message = applySettingNameMappings(error.message);
         vscode.window.showErrorMessage(message);
+        outputChannelDep.error(buildErrorMessage(error));
         record(context, TelemetryActions.vulnerabilityReportFailed, { manifest: fileName, fileName: fileName, error: message });
       }
     }
@@ -60,7 +60,7 @@ export function activate(context: vscode.ExtensionContext) {
     commands.STACK_LOGS_COMMAND,
     () => {
       if (outputChannelDep) {
-        outputChannelDep.showOutputChannel();
+        outputChannelDep.show();
       } else {
         vscode.window.showInformationMessage(StatusMessages.WIN_SHOW_LOGS);
       }
@@ -254,6 +254,7 @@ function registerStackAnalysisCommands(context: vscode.ExtensionContext) {
     } catch (error) {
       const message = applySettingNameMappings(error.message);
       vscode.window.showErrorMessage(message);
+      outputChannelDep.error(buildErrorMessage(error));
       record(context, TelemetryActions.vulnerabilityReportFailed, { manifest: fileName, fileName: fileName, error: message });
     }
   };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
         record(context, TelemetryActions.componentAnalysisVulnerabilityReportQuickfixOption, { manifest: fileName, fileName: fileName });
       }
       try {
-        await generateRHDAReport(context, filePath);
+        await generateRHDAReport(context, filePath, outputChannelDep);
         record(context, TelemetryActions.vulnerabilityReportDone, { manifest: fileName, fileName: fileName });
       } catch (error) {
         const message = applySettingNameMappings(error.message);
@@ -249,7 +249,7 @@ function registerStackAnalysisCommands(context: vscode.ExtensionContext) {
   const invokeFullStackReport = async (filePath: string) => {
     const fileName = path.basename(filePath);
     try {
-      await generateRHDAReport(context, filePath);
+      await generateRHDAReport(context, filePath, outputChannelDep);
       record(context, TelemetryActions.vulnerabilityReportDone, { manifest: fileName, fileName: fileName });
     } catch (error) {
       const message = applySettingNameMappings(error.message);

--- a/src/imageAnalysis.ts
+++ b/src/imageAnalysis.ts
@@ -7,6 +7,8 @@ import { globalConfig } from './config';
 import { imageAnalysisService } from './exhortServices';
 import { StatusMessages, Titles } from './constants';
 import { updateCurrentWebviewPanel } from './rhda';
+import { outputChannelDep } from './extension';
+import { buildErrorMessage } from './utils';
 
 /**
  * Represents options for image analysis.
@@ -182,6 +184,7 @@ class DockerImageAnalysis implements IImageAnalysis {
             p.report({ message: StatusMessages.WIN_ANALYZING_DEPENDENCIES });
 
             try {
+                outputChannelDep.info(`generating image analysis report for "${this.filePath}"`);
 
                 // execute image analysis
                 const promise = imageAnalysisService(this.images, this.options);
@@ -192,11 +195,15 @@ class DockerImageAnalysis implements IImageAnalysis {
 
                 p.report({ message: StatusMessages.WIN_SUCCESS_DEPENDENCY_ANALYSIS });
 
+                outputChannelDep.info(`done generating image analysis report for "${this.filePath}"`);
+
                 this.imageAnalysisReportHtml = resp;
             } catch (error) {
                 p.report({ message: StatusMessages.WIN_FAILURE_DEPENDENCY_ANALYSIS });
 
                 updateCurrentWebviewPanel('error');
+
+                outputChannelDep.error(buildErrorMessage(error));
 
                 throw error;
             }

--- a/src/rhda.ts
+++ b/src/rhda.ts
@@ -8,6 +8,7 @@ import { executeStackAnalysis } from './stackAnalysis';
 import { DependencyReportPanel } from './dependencyReportPanel';
 import { globalConfig } from './config';
 import { executeDockerImageAnalysis } from './imageAnalysis';
+import { DepOutputChannel } from './depOutputChannel';
 
 /**
  * Represents supported file types for analysis.
@@ -96,15 +97,15 @@ async function writeReportToFile(data: string) {
  * @param filePath The path of the file for analysis.
  * @returns A promise that resolves once the report generation is complete.
  */
-async function generateRHDAReport(context: vscode.ExtensionContext, filePath: string) {
+async function generateRHDAReport(context: vscode.ExtensionContext, filePath: string, outputChannel: DepOutputChannel) {
   const fileType = getFileType(filePath);
   if (fileType) {
     await triggerWebviewPanel(context);
     let resp: string;
     if (fileType === 'docker') {
-      resp = await executeDockerImageAnalysis(filePath);
+      resp = await executeDockerImageAnalysis(filePath, outputChannel);
     } else {
-      resp = await executeStackAnalysis(filePath);
+      resp = await executeStackAnalysis(filePath, outputChannel);
     }
     /* istanbul ignore else */
     if (DependencyReportPanel.currentPanel) {

--- a/src/stackAnalysis.ts
+++ b/src/stackAnalysis.ts
@@ -6,15 +6,15 @@ import { StatusMessages, Titles } from './constants';
 import { stackAnalysisService } from './exhortServices';
 import { globalConfig } from './config';
 import { updateCurrentWebviewPanel } from './rhda';
-import { outputChannelDep } from './extension';
 import { buildErrorMessage } from './utils';
+import { DepOutputChannel } from './depOutputChannel';
 
 /**
  * Executes the RHDA stack analysis process.
  * @param manifestFilePath The file path to the manifest file for analysis.
  * @returns The stack analysis response string.
  */
-export async function executeStackAnalysis(manifestFilePath: string): Promise<string> {
+export async function executeStackAnalysis(manifestFilePath: string, outputChannel: DepOutputChannel): Promise<string> {
   return await vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: Titles.EXT_TITLE }, async p => {
     p.report({ message: StatusMessages.WIN_ANALYZING_DEPENDENCIES });
 
@@ -40,7 +40,7 @@ export async function executeStackAnalysis(manifestFilePath: string): Promise<st
 
     // execute stack analysis
     try {
-      outputChannelDep.info(`generating stack analysis report for "${manifestFilePath}"`);
+      outputChannel.info(`generating stack analysis report for "${manifestFilePath}"`);
 
       const promise = stackAnalysisService(manifestFilePath, options);
 
@@ -50,7 +50,7 @@ export async function executeStackAnalysis(manifestFilePath: string): Promise<st
 
       updateCurrentWebviewPanel(resp);
 
-      outputChannelDep.info(`done generating stack analysis report for "${manifestFilePath}"`);
+      outputChannel.info(`done generating stack analysis report for "${manifestFilePath}"`);
 
       p.report({ message: StatusMessages.WIN_SUCCESS_DEPENDENCY_ANALYSIS });
 
@@ -60,7 +60,7 @@ export async function executeStackAnalysis(manifestFilePath: string): Promise<st
 
       updateCurrentWebviewPanel('error');
 
-      outputChannelDep.error(buildErrorMessage(err));
+      outputChannel.error(buildErrorMessage(err));
 
       throw err;
     }

--- a/src/stackAnalysis.ts
+++ b/src/stackAnalysis.ts
@@ -6,7 +6,8 @@ import { StatusMessages, Titles } from './constants';
 import { stackAnalysisService } from './exhortServices';
 import { globalConfig } from './config';
 import { updateCurrentWebviewPanel } from './rhda';
-
+import { outputChannelDep } from './extension';
+import { buildErrorMessage } from './utils';
 
 /**
  * Executes the RHDA stack analysis process.
@@ -39,6 +40,8 @@ export async function executeStackAnalysis(manifestFilePath: string): Promise<st
 
     // execute stack analysis
     try {
+      outputChannelDep.info(`generating stack analysis report for "${manifestFilePath}"`);
+
       const promise = stackAnalysisService(manifestFilePath, options);
 
       p.report({ message: StatusMessages.WIN_GENERATING_DEPENDENCIES });
@@ -47,6 +50,8 @@ export async function executeStackAnalysis(manifestFilePath: string): Promise<st
 
       updateCurrentWebviewPanel(resp);
 
+      outputChannelDep.info(`done generating stack analysis report for "${manifestFilePath}"`);
+
       p.report({ message: StatusMessages.WIN_SUCCESS_DEPENDENCY_ANALYSIS });
 
       return resp;
@@ -54,6 +59,8 @@ export async function executeStackAnalysis(manifestFilePath: string): Promise<st
       p.report({ message: StatusMessages.WIN_FAILURE_DEPENDENCY_ANALYSIS });
 
       updateCurrentWebviewPanel('error');
+
+      outputChannelDep.error(buildErrorMessage(err));
 
       throw err;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,3 +19,12 @@ export function applySettingNameMappings(message: string): string {
 
     return modifiedMessage;
 }
+
+export function buildErrorMessage(error: Error): string {
+    let message = error.message;
+    while (error.cause) {
+        message = `${message}: ${(error.cause as Error).message}`;
+        error = error.cause as Error;
+    }
+    return message;
+}

--- a/test/depOutputChannel.test.ts
+++ b/test/depOutputChannel.test.ts
@@ -28,7 +28,7 @@ suite('DepOutputChannel module', () => {
   test('getOutputChannel should return OutputChannel with default name', () => {
     const depOutputChannel = new DepOutputChannel();
 
-    let outputChannel = depOutputChannel.getOutputChannel();
+    let outputChannel = depOutputChannel.outputChannel
 
     expect(outputChannel.name).equals(Titles.EXT_TITLE);
   });
@@ -36,7 +36,7 @@ suite('DepOutputChannel module', () => {
   test('getOutputChannel should return OutputChannel with custom name', () => {
     const depOutputChannel = new DepOutputChannel('Mock Channel');
 
-    let outputChannel = depOutputChannel.getOutputChannel();
+    let outputChannel = depOutputChannel.outputChannel
 
     expect(outputChannel.name).equals('Mock Channel');
   });
@@ -45,7 +45,7 @@ suite('DepOutputChannel module', () => {
     const depOutputChannel = new DepOutputChannel();
     const showStub = sandbox.stub(depOutputChannel.outputChannel, 'show');
 
-    depOutputChannel.showOutputChannel();
+    depOutputChannel.show();
 
     expect(showStub).to.be.calledOnce;
   });
@@ -54,7 +54,7 @@ suite('DepOutputChannel module', () => {
     const depOutputChannel = new DepOutputChannel();
     const clearStub = sandbox.stub(depOutputChannel.outputChannel, 'clear');
 
-    depOutputChannel.clearOutputChannel();
+    depOutputChannel.clear();
 
     expect(clearStub).to.be.calledOnce;
   });
@@ -63,7 +63,7 @@ suite('DepOutputChannel module', () => {
     const depOutputChannel = new DepOutputChannel();
     const appendStub = sandbox.stub(depOutputChannel.outputChannel, 'append');
 
-    depOutputChannel.addMsgOutputChannel('Mock Message');
+    depOutputChannel.info('Mock Message');
 
     expect(appendStub).to.be.calledOnce;
   });

--- a/test/depOutputChannel.test.ts
+++ b/test/depOutputChannel.test.ts
@@ -61,7 +61,7 @@ suite('DepOutputChannel module', () => {
 
   test('addMsgOutputChannel should call add() once', () => {
     const depOutputChannel = new DepOutputChannel();
-    const appendStub = sandbox.stub(depOutputChannel.outputChannel, 'append');
+    const appendStub = sandbox.stub(depOutputChannel.outputChannel, 'appendLine');
 
     depOutputChannel.info('Mock Message');
 

--- a/test/imageAnalysis.test.ts
+++ b/test/imageAnalysis.test.ts
@@ -7,9 +7,11 @@ import * as exhortServices from '../src/exhortServices';
 import { globalConfig } from '../src/config';
 import { executeDockerImageAnalysis } from '../src/imageAnalysis'
 import * as rhda from '../src/rhda'
+import { DepOutputChannel } from '../src/depOutputChannel';
 
 const expect = chai.expect;
 chai.use(sinonChai);
+const outputChannel = new DepOutputChannel('test')
 
 suite('ImageAnalysis module', () => {
     let sandbox: sinon.SinonSandbox;
@@ -45,7 +47,7 @@ FROM scratch
         sandbox.stub(fs, 'readFileSync').returns(encodedMockFileContent);
         const updateCurrentWebviewPanelSpy = sandbox.spy(rhda, 'updateCurrentWebviewPanel');
 
-        const response = await executeDockerImageAnalysis(mockPath);
+        const response = await executeDockerImageAnalysis(mockPath, outputChannel);
 
         expect(imageAnalysisServiceStub.calledOnce).to.be.true;
         expect(response).to.eq(mockReponse);
@@ -57,7 +59,7 @@ FROM scratch
         sandbox.stub(fs, 'readFileSync').returns(encodedMockFileContent);
         const updateCurrentWebviewPanelSpy = sandbox.spy(rhda, 'updateCurrentWebviewPanel');
 
-        await executeDockerImageAnalysis(mockPath)
+        await executeDockerImageAnalysis(mockPath, outputChannel)
             .then(() => {
                 throw (new Error('should have thrown error'))
             })
@@ -72,7 +74,7 @@ FROM scratch
         sandbox.stub(fs, 'readFileSync').throws(new Error('Mock Error'));
         const updateCurrentWebviewPanelSpy = sandbox.spy(rhda, 'updateCurrentWebviewPanel');
 
-        await executeDockerImageAnalysis(mockPath)
+        await executeDockerImageAnalysis(mockPath, outputChannel)
             .then(() => {
                 throw (new Error('should have thrown error'))
             })

--- a/test/rhda.test.ts
+++ b/test/rhda.test.ts
@@ -10,9 +10,12 @@ import { globalConfig } from '../src/config';
 import * as rhda from '../src/rhda'
 import { context } from './vscontext.mock';
 import { DependencyReportPanel } from '../src/dependencyReportPanel';
+import { DepOutputChannel } from '../src/depOutputChannel';
 
 const expect = chai.expect;
 chai.use(sinonChai);
+const outputChannel = new DepOutputChannel('test')
+
 
 suite('RHDA module', () => {
     let sandbox: sinon.SinonSandbox;
@@ -49,7 +52,7 @@ suite('RHDA module', () => {
         const imageAnalysisServiceStub = sandbox.stub(imageAnalysis, 'executeDockerImageAnalysis').resolves(mockReponse)
         const showInformationMessageSpy = sandbox.spy(vscode.window, 'showInformationMessage');
 
-        await rhda.generateRHDAReport(context, unsupportedFilePath);
+        await rhda.generateRHDAReport(context, unsupportedFilePath, outputChannel);
 
         expect(authorizeRHDAStub.calledOnce).to.be.false;
         expect(stackAnalysisServiceStub.calledOnce).to.be.false;
@@ -62,7 +65,7 @@ suite('RHDA module', () => {
         const stackAnalysisServiceStub = sandbox.stub(stackAnalysis, 'executeStackAnalysis').resolves(mockReponse)
         const writeFileStub = sandbox.stub(fs.promises, 'writeFile').resolves(null)
 
-        await rhda.generateRHDAReport(context, mockGoPath);
+        await rhda.generateRHDAReport(context, mockGoPath, outputChannel);
 
         expect(authorizeRHDAStub.calledOnce).to.be.true;
         expect(stackAnalysisServiceStub.calledOnce).to.be.true;
@@ -74,7 +77,7 @@ suite('RHDA module', () => {
         const imageAnalysisServiceStub = sandbox.stub(imageAnalysis, 'executeDockerImageAnalysis').resolves(mockReponse)
         const writeFileStub = sandbox.stub(fs.promises, 'writeFile').resolves(null)
 
-        await rhda.generateRHDAReport(context, mockDockerfilePath);
+        await rhda.generateRHDAReport(context, mockDockerfilePath, outputChannel);
 
         expect(authorizeRHDAStub.calledOnce).to.be.true;
         expect(imageAnalysisServiceStub.calledOnce).to.be.true;
@@ -85,7 +88,7 @@ suite('RHDA module', () => {
         const authorizeRHDAStub = sandbox.stub(globalConfig, 'authorizeRHDA').resolves();
         const stackAnalysisServiceStub = sandbox.stub(stackAnalysis, 'executeStackAnalysis').rejects(new Error('Mock Error'));
 
-        await rhda.generateRHDAReport(context, mockMavenPath)
+        await rhda.generateRHDAReport(context, mockMavenPath, outputChannel)
             .then(() => {
                 throw (new Error('should have thrown error'))
             })
@@ -100,7 +103,7 @@ suite('RHDA module', () => {
         const authorizeRHDAStub = sandbox.stub(globalConfig, 'authorizeRHDA').resolves();
         const imageAnalysisServiceStub = sandbox.stub(imageAnalysis, 'executeDockerImageAnalysis').rejects(new Error('Mock Error'));
 
-        await rhda.generateRHDAReport(context, mockContainerfilePath)
+        await rhda.generateRHDAReport(context, mockContainerfilePath, outputChannel)
             .then(() => {
                 throw (new Error('should have thrown error'))
             })
@@ -116,7 +119,7 @@ suite('RHDA module', () => {
         const stackAnalysisServiceStub = sandbox.stub(stackAnalysis, 'executeStackAnalysis').resolves(mockReponse)
         const writeFileStub = sandbox.stub(fs.promises, 'writeFile').throws(new Error('Mock Error'))
 
-        await rhda.generateRHDAReport(context, mockNpmPath)
+        await rhda.generateRHDAReport(context, mockNpmPath, outputChannel)
             .then(() => {
                 throw (new Error('should have thrown error'))
             })
@@ -134,7 +137,7 @@ suite('RHDA module', () => {
         sandbox.stub(fs, 'existsSync').returns(false);
         const mkdirSyncStub = sandbox.stub(fs, 'mkdirSync').throws(new Error('Mock Error'));
 
-        await rhda.generateRHDAReport(context, mockPythonPath)
+        await rhda.generateRHDAReport(context, mockPythonPath, outputChannel)
             .then(() => {
                 throw (new Error('should have thrown error'))
 
@@ -152,7 +155,7 @@ suite('RHDA module', () => {
         const stackAnalysisServiceStub = sandbox.stub(stackAnalysis, 'executeStackAnalysis').resolves(mockReponse)
         const writeFileStub = sandbox.stub(fs.promises, 'writeFile').resolves(null)
 
-        await rhda.generateRHDAReport(context, mockGradlePath);
+        await rhda.generateRHDAReport(context, mockGradlePath, outputChannel);
 
         expect(authorizeRHDAStub.calledOnce).to.be.true;
         expect(stackAnalysisServiceStub.calledOnce).to.be.true;

--- a/test/stackAnalysis.test.ts
+++ b/test/stackAnalysis.test.ts
@@ -7,9 +7,11 @@ import { globalConfig } from '../src/config';
 import { DependencyReportPanel } from '../src/dependencyReportPanel';
 import { executeStackAnalysis } from '../src/stackAnalysis'
 import * as templates from '../src/template';
+import { DepOutputChannel } from '../src/depOutputChannel';
 
 const expect = chai.expect;
 chai.use(sinonChai);
+const outputChannel = new DepOutputChannel('test')
 
 suite('StackAnalysis module', () => {
   let sandbox: sinon.SinonSandbox;
@@ -35,7 +37,7 @@ suite('StackAnalysis module', () => {
   test('should generate RHDA report for supported file', async () => {
     const stackAnalysisServiceStub = sandbox.stub(exhortServices, 'stackAnalysisService').resolves(mockReponse)
 
-    await executeStackAnalysis(mockPath);
+    await executeStackAnalysis(mockPath, outputChannel);
 
     expect(stackAnalysisServiceStub.calledOnce).to.be.true;
     expect(DependencyReportPanel.data).to.eq(mockReponse);
@@ -44,7 +46,7 @@ suite('StackAnalysis module', () => {
   test('should fail to generate RHDA report for supported file', async () => {
     const stackAnalysisServiceStub = sandbox.stub(exhortServices, 'stackAnalysisService').rejects(new Error('Mock Error'));
 
-    await executeStackAnalysis(mockPath)
+    await executeStackAnalysis(mockPath, outputChannel)
       .then(() => {
         throw (new Error('should have thrown error'))
       })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "esnext",
     "lib": [
       "es6",
-      "es2021",
+      "es2022",
       "dom"
     ],
     "module": "commonjs",


### PR DESCRIPTION
Instead of having a completely empty log section, time to actually put something semi-useful for the "Red Hat Dependency Analytics: Debug logs" command :smile: 