### PR TITLE
fix: released package.json version was version behind

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Update package with new version
+        run: npm version ${{ vars.VERSION_BUMPING_TYPE }} --no-git-tag-version
+
       - name: Compile for test
         run: npm run test-compile
 
@@ -176,7 +179,7 @@ jobs:
             asset_name=$(basename "$file")
             upload_url=$(echo "${{ steps.new_release.outputs.upload_url }}" | sed "s/{?name,label}/?name=$asset_name/g")
             curl --data-binary @"$file" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/octet-stream" \
-            "$upload_url"
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Content-Type: application/octet-stream" \
+              "$upload_url"
           done


### PR DESCRIPTION
We were building the vsix and only _later_ bumping the version, so package.json in the vsix contained version X.Y.Z-1 but the code for X.Y.Z