### PR TITLE
fix: conflict with gradle extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,6 +118,7 @@ export function activate(context: vscode.ExtensionContext) {
           { scheme: 'file', language: 'go.mod' },
           { scheme: 'file', language: 'groovy' },
           { scheme: 'file', language: 'kotlin' },
+          { scheme: 'file', language: 'gradle' },
           { scheme: 'file', language: 'dockerfile' }
         ]
       };


### PR DESCRIPTION
Fix https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/776

The conflict was caused by how the Gradle extension updates how Gradle build files are reported to the listeners.