### PR TITLE
fix: component analysis status bar error tooltip not showing

### DIFF
--- a/src/caStatusBarProvider.ts
+++ b/src/caStatusBarProvider.ts
@@ -25,9 +25,10 @@ class CAStatusBarProvider implements Disposable {
   public showSummary(text: string, uri: Uri): void {
     this.statusBarItem.text = text;
     this.statusBarItem.command = {
+      // Unused but required?
       title: PromptText.FULL_STACK_PROMPT_TEXT,
       command: commands.STACK_ANALYSIS_FROM_STATUS_BAR_COMMAND,
-      arguments: [uri]
+      arguments: [uri],
     };
     this.statusBarItem.tooltip = PromptText.FULL_STACK_PROMPT_TEXT;
     this.statusBarItem.show();
@@ -39,9 +40,11 @@ class CAStatusBarProvider implements Disposable {
   public setError(): void {
     this.statusBarItem.text = `$(error) RHDA analysis has failed`;
     this.statusBarItem.command = {
+      // Unused but required?
       title: PromptText.LSP_FAILURE_TEXT,
       command: commands.STACK_LOGS_COMMAND,
     };
+    this.statusBarItem.tooltip = PromptText.LSP_FAILURE_TEXT;
   }
 
   /**


### PR DESCRIPTION
When theres a CA error, the status bar item would still display the original "Open Red Hat Dependency Analytics Report" tooltip instead of "Open the output window"
![image](https://github.com/user-attachments/assets/ab8ea4b0-610f-4ea7-bedc-938e32573fa4)
Turns out `command.title` is ignored for tooltips.
![image](https://github.com/user-attachments/assets/8025b81d-1b5a-43ee-bed4-7afa00562a49)
