### PR TITLE
feat: improve UX for error messages in logs & notifications

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,57 +1,58 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 module.exports = {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint"],
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/eslint-recommended",
-        "plugin:@typescript-eslint/recommended"
+    'root': true,
+    'parser': '@typescript-eslint/parser',
+    'plugins': ['@typescript-eslint'],
+    'extends': [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:@typescript-eslint/recommended'
     ],
-    "rules": {
-        "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-require-imports": "error",
-        "@typescript-eslint/no-unused-expressions": "error",
-        "@typescript-eslint/naming-convention": [ 
-            "error",
+    'rules': {
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-require-imports': 'error',
+        '@typescript-eslint/no-unused-expressions': 'error',
+        '@typescript-eslint/naming-convention': [
+            'error',
             {
-                "selector": "default",
-                "format": ["camelCase"]
+                'selector': 'default',
+                'format': ['camelCase']
             },
             {
-                "selector": ["class", "interface", "enum"],
-                "format": ["PascalCase"]
+                'selector': ['class', 'interface', 'enum'],
+                'format': ['PascalCase']
             },
             {
-                "selector": ["enumMember", "variable", "property", "method"],
-                "format": ["UPPER_CASE", "camelCase"],
-                "leadingUnderscore": "allow"
+                'selector': ['enumMember', 'variable', 'property', 'method'],
+                'format': ['UPPER_CASE', 'camelCase'],
+                'leadingUnderscore': 'allow'
             }
         ],
-        "@typescript-eslint/semi": ["error", "always"],
-        "@typescript-eslint/quotes": [
-            "error",
-            "single",
+        '@typescript-eslint/semi': ['error', 'always'],
+        '@typescript-eslint/quotes': [
+            'error',
+            'single',
             {
-                "allowTemplateLiterals": true,
-                "avoidEscape": true
+                'allowTemplateLiterals': true,
+                'avoidEscape': true
             }
         ],
-        "@typescript-eslint/no-shadow": "error",
-        "@typescript-eslint/no-redeclare": "error",
-        "no-async-promise-executor": "off",
-        "no-redeclare": "off",
-        "no-duplicate-case": "error",
-        "no-shadow": "off",
-        "curly": "error",
-        "semi": "off",
-        "eqeqeq": ["error", "always"],
-        "quotes": "off",
-        "no-debugger": "error",
-        "no-empty": "error",
-        "no-var": "error",
-        "no-unsafe-finally": "error",
-        "new-parens": "error",
-        "no-throw-literal": "error",
-        "no-useless-catch": "off"
+        '@typescript-eslint/no-shadow': 'error',
+        '@typescript-eslint/no-redeclare': 'error',
+        'no-async-promise-executor': 'off',
+        'no-redeclare': 'off',
+        'no-duplicate-case': 'error',
+        'no-shadow': 'off',
+        'curly': 'error',
+        'semi': 'off',
+        'eqeqeq': ['warn', 'always', { 'null': 'never' }],
+        'quotes': 'off',
+        'no-debugger': 'error',
+        'no-empty': 'error',
+        'no-var': 'error',
+        'no-unsafe-finally': 'error',
+        'new-parens': 'error',
+        'no-throw-literal': 'error',
+        'no-useless-catch': 'off'
     }
 }

--- a/src/caNotification.ts
+++ b/src/caNotification.ts
@@ -140,7 +140,7 @@ class CANotification {
    */
   public popupText(): string {
     const text: string = Array.from(this.vulnCount.entries())
-      .map(([provider, vulnCount]) => `Found ${vulnCount} direct ${this.singularOrPlural(vulnCount)} for ${this.capitalizeEachWord(provider)} Provider.`)
+      .map(([provider, vulnCount]) => `Found ${vulnCount} direct ${this.singularOrPlural(vulnCount)} in ${this.uri.fsPath} for ${this.capitalizeEachWord(provider)} Provider.`)
       .join(' ');
     return text || this.warningText().replace(/\$\((.*?)\)/g, '');
   }

--- a/src/dependencyAnalysis/diagnostics.ts
+++ b/src/dependencyAnalysis/diagnostics.ts
@@ -10,7 +10,7 @@ import { executeComponentAnalysis, DependencyData } from './analysis';
 import { Vulnerability } from '../vulnerability';
 import { VERSION_PLACEHOLDER, GRADLE } from '../constants';
 import { clearCodeActionsMap, registerCodeAction, generateSwitchToRecommendedVersionAction } from '../codeActionHandler';
-import { buildErrorMessage } from '../utils';
+import { buildLogErrorMessage, buildNotificationErrorMessage } from '../utils';
 import { AbstractDiagnosticsPipeline } from '../diagnosticsPipeline';
 import { Diagnostic, DiagnosticSeverity, Uri } from 'vscode';
 import { notifications, outputChannelDep } from '../extension';
@@ -112,9 +112,9 @@ async function performDiagnostics(diagnosticFilePath: Uri, contents: string, pro
 
     diagnosticsPipeline.reportDiagnostics();
   } catch (error) {
-    outputChannelDep.warn(`component analysis error: ${buildErrorMessage(error as Error)}\n${(error as Error).stack}`);
+    outputChannelDep.warn(`component analysis error: ${buildLogErrorMessage(error as Error)}`);
     notifications.emit('caError', {
-      errorMessage: (error as Error).message,
+      errorMessage: buildNotificationErrorMessage(error as Error),
       uri: diagnosticFilePath,
     });
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import { caStatusBarProvider } from './caStatusBarProvider';
 import { CANotification, CANotificationData } from './caNotification';
 import { DepOutputChannel } from './depOutputChannel';
 import { record, startUp, TelemetryActions } from './redhatTelemetry';
-import { applySettingNameMappings, buildErrorMessage } from './utils';
+import { applySettingNameMappings, buildLogErrorMessage } from './utils';
 import { clearCodeActionsMap, getDiagnosticsCodeActions } from './codeActionHandler';
 import { AnalysisMatcher } from './fileHandler';
 import { EventEmitter } from 'node:events';
@@ -67,9 +67,10 @@ export async function activate(context: vscode.ExtensionContext) {
         await generateRHDAReport(context, fspath, outputChannelDep);
         record(context, TelemetryActions.vulnerabilityReportDone, { manifest: fileName, fileName: fileName });
       } catch (error) {
+        // TODO: dont show raw message
         const message = applySettingNameMappings((error as Error).message);
-        vscode.window.showErrorMessage(message);
-        outputChannelDep.error(buildErrorMessage((error as Error)));
+        vscode.window.showErrorMessage(`RHDA error while analyzing ${filePath}: ${message}`);
+        outputChannelDep.error(buildLogErrorMessage((error as Error)));
         record(context, TelemetryActions.vulnerabilityReportFailed, { manifest: fileName, fileName: fileName, error: message });
       }
     }
@@ -220,8 +221,8 @@ function registerStackAnalysisCommands(context: vscode.ExtensionContext) {
       record(context, TelemetryActions.vulnerabilityReportDone, { manifest: fileName, fileName: fileName });
     } catch (error) {
       const message = applySettingNameMappings((error as Error).message);
-      vscode.window.showErrorMessage(message);
-      outputChannelDep.error(buildErrorMessage((error as Error)));
+      vscode.window.showErrorMessage(`RHDA error while analyzing ${filePath}: ${message}`);
+      outputChannelDep.error(buildLogErrorMessage((error as Error)));
       record(context, TelemetryActions.vulnerabilityReportFailed, { manifest: fileName, fileName: fileName, error: message });
     }
   };

--- a/src/fileHandler.ts
+++ b/src/fileHandler.ts
@@ -11,44 +11,44 @@ import { ImageProvider as Docker } from './providers/docker';
 import { outputChannelDep } from './extension';
 
 export class AnalysisMatcher {
-  matchers: Array<{ scheme: string, pattern: RegExp, callback: (path: Uri, contents: string) => void }> = [
+  matchers: Array<{ scheme: string, pattern: RegExp, callback: (path: Uri, contents: string) => Promise<void> }> = [
     {
       scheme: 'file', pattern: new RegExp('^package\\.json$'), callback: (path: Uri, contents: string) => {
-        dependencyDiagnostics.performDiagnostics(path, contents, new PackageJson());
+        return dependencyDiagnostics.performDiagnostics(path, contents, new PackageJson());
       }
     },
     {
       scheme: 'file', pattern: new RegExp('^pom\\.xml$'), callback: (path: Uri, contents: string) => {
-        dependencyDiagnostics.performDiagnostics(path, contents, new PomXml());
+        return dependencyDiagnostics.performDiagnostics(path, contents, new PomXml());
       }
     },
     {
       scheme: 'file', pattern: new RegExp('^go\\.mod$'), callback: (path: Uri, contents: string) => {
-        dependencyDiagnostics.performDiagnostics(path, contents, new GoMod());
+        return dependencyDiagnostics.performDiagnostics(path, contents, new GoMod());
       }
     },
     {
       scheme: 'file', pattern: new RegExp('^requirements\\.txt$'), callback: (path: Uri, contents: string) => {
-        dependencyDiagnostics.performDiagnostics(path, contents, new RequirementsTxt());
+        return dependencyDiagnostics.performDiagnostics(path, contents, new RequirementsTxt());
       }
     },
     {
       scheme: 'file', pattern: new RegExp('^build\\.gradle$'), callback: (path: Uri, contents: string) => {
-        dependencyDiagnostics.performDiagnostics(path, contents, new BuildGradle());
+        return dependencyDiagnostics.performDiagnostics(path, contents, new BuildGradle());
       }
     },
     {
       scheme: 'file', pattern: new RegExp('^(Dockerfile|Containerfile)$'), callback: (path: Uri, contents: string) => {
-        imageDiagnostics.performDiagnostics(path, contents, new Docker());
+        return imageDiagnostics.performDiagnostics(path, contents, new Docker());
       }
     }
   ];
 
-  handle(doc: TextDocument) {
+  async handle(doc: TextDocument) {
     for (const matcher of this.matchers) {
       if (matcher.pattern.test(basename(doc.fileName))) {
         outputChannelDep.info(`generating component analysis diagnostics for "${doc.fileName}"`);
-        matcher.callback(doc.uri, doc.getText());
+        await matcher.callback(doc.uri, doc.getText());
         outputChannelDep.info(`done generating component analysis diagnostics for "${doc.fileName}"`);
       }
     }

--- a/src/imageAnalysis.ts
+++ b/src/imageAnalysis.ts
@@ -8,7 +8,7 @@ import { imageAnalysisService } from './exhortServices';
 import { StatusMessages, Titles } from './constants';
 import { Options } from '@trustification/exhort-javascript-api';
 import { updateCurrentWebviewPanel } from './rhda';
-import { buildErrorMessage } from './utils';
+import { buildLogErrorMessage } from './utils';
 import { DepOutputChannel } from './depOutputChannel';
 
 /**
@@ -190,7 +190,7 @@ class DockerImageAnalysis {
 
         updateCurrentWebviewPanel('error');
 
-        this.outputChannel.error(buildErrorMessage(error as Error));
+        this.outputChannel.error(buildLogErrorMessage(error as Error));
 
         throw error;
       }

--- a/src/imageAnalysis/diagnostics.ts
+++ b/src/imageAnalysis/diagnostics.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { buildErrorMessage } from '../utils';
+import { buildLogErrorMessage, buildNotificationErrorMessage } from '../utils';
 import { IImageProvider, ImageMap, getRange } from '../imageAnalysis/collector';
 import { AbstractDiagnosticsPipeline } from '../diagnosticsPipeline';
 import { clearCodeActionsMap, registerCodeAction, generateRedirectToRecommendedVersionAction } from '../codeActionHandler';
@@ -104,9 +104,9 @@ async function performDiagnostics(diagnosticFilePath: Uri, contents: string, pro
     diagnosticsPipeline.reportDiagnostics();
 
   } catch (error) {
-    outputChannelDep.warn(`component analysis error: ${buildErrorMessage(error as Error)}`);
+    outputChannelDep.warn(`component analysis error: ${buildLogErrorMessage(error as Error)}`);
     notifications.emit('caError', {
-      errorMessage: (error as Error).message,
+      errorMessage: buildNotificationErrorMessage(error as Error),
       uri: diagnosticFilePath,
     });
   }

--- a/src/stackAnalysis.ts
+++ b/src/stackAnalysis.ts
@@ -6,7 +6,7 @@ import { StatusMessages, Titles } from './constants';
 import { stackAnalysisService } from './exhortServices';
 import { globalConfig } from './config';
 import { updateCurrentWebviewPanel } from './rhda';
-import { buildErrorMessage } from './utils';
+import { buildLogErrorMessage } from './utils';
 import { DepOutputChannel } from './depOutputChannel';
 import { Options } from '@trustification/exhort-javascript-api';
 
@@ -65,7 +65,7 @@ export async function executeStackAnalysis(manifestFilePath: string, outputChann
 
       updateCurrentWebviewPanel('error');
 
-      outputChannel.error(buildErrorMessage(err as Error));
+      outputChannel.error(buildLogErrorMessage(err as Error));
 
       throw err;
     }

--- a/test/caNotification.test.ts
+++ b/test/caNotification.test.ts
@@ -70,7 +70,7 @@ suite('CANotification module', () => {
         expect(notification.origin().toString()).to.equal('file:///mock/path');
         expect(notification.isDone()).to.be.true;
         expect(notification.hasWarning()).to.be.true;
-        expect(notification.popupText()).to.equal('Found 1 direct vulnerability for Snyk Provider.');
+        expect(notification.popupText()).to.equal('Found 1 direct vulnerability in /mock/path for Snyk Provider.');
         expect(notification.statusText()).to.equal('$(warning) 1 direct vulnerability found for all the providers combined');
     });
 
@@ -89,7 +89,7 @@ suite('CANotification module', () => {
         expect(notification.origin().toString()).to.equal('file:///mock/path');
         expect(notification.isDone()).to.be.true;
         expect(notification.hasWarning()).to.be.true;
-        expect(notification.popupText()).to.equal('Found 3 direct vulnerabilities for Snyk Provider.');
+        expect(notification.popupText()).to.equal('Found 3 direct vulnerabilities in /mock/path for Snyk Provider.');
         expect(notification.statusText()).to.equal('$(warning) 3 direct vulnerabilities found for all the providers combined');
     });
 
@@ -109,7 +109,7 @@ suite('CANotification module', () => {
         expect(notification.origin().toString()).to.equal('file:///mock/path');
         expect(notification.isDone()).to.be.true;
         expect(notification.hasWarning()).to.be.true;
-        expect(notification.popupText()).to.equal('Found 3 direct vulnerabilities for Snyk Provider. Found 1 direct vulnerability for Oss-Index Provider.');
+        expect(notification.popupText()).to.equal('Found 3 direct vulnerabilities in /mock/path for Snyk Provider. Found 1 direct vulnerability in /mock/path for Oss-Index Provider.');
         expect(notification.statusText()).to.equal('$(warning) 4 direct vulnerabilities found for all the providers combined');
     });
 


### PR DESCRIPTION
Changes made:

1. Vulnerabilities-found notification includes the manifest filepath 
<img width="467" height="160" alt="image" src="https://github.com/user-attachments/assets/770f1ade-d5e0-413e-9780-9f08cefdf51b" />

2. Stack analysis report errors follow the same change as in https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/799

3. Customized the logs shown in notification popup vs in logs. Notifications include less details and for certain errors with extra output (such as command errors with stdout/stderr) we direct users towards the logs Output panel