### PR TITLE
feat: add 'ignore for this file' in notifications

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -207,6 +207,16 @@ class Config {
   }
 
   /**
+   * Adds a path to the workspace-local redHatDependencyAnalytics.exclude list.
+   * @param path The path to add 
+   */
+  async addFileToExcludeList(path: string) {
+    const original = vscode.workspace.getConfiguration('redHatDependencyAnalytics').inspect('exclude');
+    const newValues = [...((original?.workspaceValue as string[] | undefined) || []), path];
+    await vscode.workspace.getConfiguration('redHatDependencyAnalytics').update('exclude', newValues);
+  }
+
+  /**
    * Authorizes the RHDA (Red Hat Dependency Analytics) service.
    * @param context The extension context for authorization.
    */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,7 @@ export enum StatusMessages {
 export enum PromptText {
   FULL_STACK_PROMPT_TEXT = `Open Red Hat Dependency Analytics Report`,
   LSP_FAILURE_TEXT = `Open the output window`,
+  IGNORE_FILE = 'Ignore this file',
 }
 
 export enum Titles {


### PR DESCRIPTION
Adds an "Ignore this file" button to notifications from component analysis errors or vulns discovered during component analysis, using user-configurable exclude patterns from https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/803

<img width="499" height="165" alt="image" src="https://github.com/user-attachments/assets/cd208020-90d9-4913-a296-ac15d917ba3b" />

Current design of the status bar doesn't allow resetting (in general the status bar needs a rework)