### PR TITLE
feat: add metric names to LLM model cards hover and only include basics

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -204,14 +204,14 @@ export async function activate(context: vscode.ExtensionContext) {
         style: { compact: true, border: [], head: [] },
       });
 
-      for (const warning of modelInfo.metrics) {
-        table.push([warning.task, warning.score.toFixed(3), warning.assessment]);
+      for (const warning of modelInfo.metrics.filter(metric => metric.metric.startsWith('pct_') || metric.metric === 'acc')) {
+        table.push([`${warning.task}: ${warning.metric}`, warning.score.toFixed(3), warning.assessment]);
       }
 
       for (const range of modelWithLoc.get(modelInfo.model_name)!) {
         diagnostics.push({
           range: range,
-          message: table.toString() + `\n\nRecommendation: Based on TrustyAI LLM-Eval, we detected moderate risks in bias, toxicity, and truthfulness. We recommend you should use Input Shield for bias protection and Output Shield for toxicity and hallucination protection.\n`,
+          message: table.toString() + `\n\nRecommendation: Based on TrustyAI LLM-Eval, we detected moderate risks in bias, toxicity, and truthfulness.\nWe recommend you should use Input Shield for bias protection and Output Shield for toxicity and hallucination protection.\n`,
           severity: vscode.DiagnosticSeverity.Information,
           source: 'Red Hat LLM Dependency Analytics',
           code: `rhdallm`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,7 +211,7 @@ export async function activate(context: vscode.ExtensionContext) {
       for (const range of modelWithLoc.get(modelInfo.model_name)!) {
         diagnostics.push({
           range: range,
-          message: table.toString() + `\n\nRecommendation: Based on TrustyAI LLM-Eval, we detected moderate risks in bias, toxicity, and truthfulness.\nWe recommend you should use Input Shield for bias protection and Output Shield for toxicity and hallucination protection.\n`,
+          message: table.toString() + `\n\nOpen the detailed report via Code Actions for further details & recommended guardrails.\n`,
           severity: vscode.DiagnosticSeverity.Information,
           source: 'Red Hat LLM Dependency Analytics',
           code: `rhdallm`


### PR DESCRIPTION
before:
<img width="901" height="432" alt="image" src="https://github.com/user-attachments/assets/4258a6cb-1e11-4d79-8d74-1fec8f0faac6" />

after:
<img width="916" height="344" alt="image" src="https://github.com/user-attachments/assets/300989c7-8f17-4e39-b03c-4913398b634b" />
