### PR TITLE
feat: add telemetry for LLM models referenced in annotations, hovered on and reports generated for

### DIFF
--- a/src/redhatTelemetry.ts
+++ b/src/redhatTelemetry.ts
@@ -17,6 +17,9 @@ enum TelemetryActions {
   vulnerabilityReportPopupIgnored = 'vulnerability_report_popup_ignored',
   componentAnalysisVulnerabilityReportQuickfixOption = 'component_analysis_vulnerability_report_quickfix_option',
   componentAnalysisRecommendationAccepted = 'component_analysis_recommendation_accepted',
+  llmAnalysisModelAnnotationsDiscovered = 'llm_analysis_model_annotations_discovered',
+  llmAnalysisDiagnosticsHovered = 'llm_analysis_diagnostics_hovered',
+  llmAnalysisReportDone = 'llm_analysis_report_done'
 }
 
 let telemetryServiceObj: TelemetryService | null = null;


### PR DESCRIPTION
1.
LLM models referenced in `@rhda` annotations that are known on the backend.
Key: `llm_analysis_model_annotations_discovered`
Values: a sorted array of model names
Frequency: whenever a file contains the `@rhda` annotation with a set of models differing to the previous set of models associated with the file is opened or updated

2.
LLM diagnostic/squiggle is hovered over.
Key: `llm_analysis_diagnostics_hovered`
Values: `modelName`: the model name
Frequency: whenever code actions are generated, which should happen when hovering over the generated diagnostics/squiggle. This may be cached by the editor, but at a minimum should happen at least once per code range

3.
LLM analysis report is generated
Key: `llm_analysis_report_done`
Values: `modelName`: the model name
Frequency: whenever the `LLM_MODELS_ANALYSIS_REPORT` command is executed via the code action