### PR TITLE
chore(ci): generate deployment builds using the commit sha

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -41,31 +41,15 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Get latest EA version
+      - name: Get commit SHA EA version
         id: ea_version
         run: |
           # Get the current version from package.json
           base_version=$(node -p "require('./package.json').version")
           
-          # Get the latest EA version for this base version
-          latest_ea=$(npm view @fabric8-analytics/fabric8-analytics-vscode-extension versions --json | grep -o "\"$base_version-ea\.[0-9]*\"" | sort -V | tail -n 1)
-          
-          if [ -z "$latest_ea" ]; then
-            # If no EA version exists, start with .1
-            ea_number=1
-          else
-            # Extract the number and increment
-            ea_number=$(echo $latest_ea | grep -o "[0-9]*" | tail -n 1)
-            ea_number=$((ea_number + 1))
-          fi
-          
-          # Create the new EA version
-          ea_version="v${base_version}-ea.${ea_number}"
-          echo "version=$ea_version" >> "$GITHUB_OUTPUT"
-
-      - name: Update package with EA version
-        run: |
-          npm version ${{ steps.ea_version.outputs.version }} --no-git-tag-version --allow-same-version
+          # Get short commit SHA
+          short_sha=$(git rev-parse --short HEAD)
+          echo "version=$base_version-ea.$short_sha" >> "$GITHUB_OUTPUT"
 
       - name: Compile for test
         run: npm run test-compile


### PR DESCRIPTION
Name stage builds using the short commit sha for better traceability.