### PR TITLE
fix: revert "don't run component analysis for files opened not by the user"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,16 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((doc) => fileHandler.handle(doc, outputChannelDep)));
   // Anecdotaly, some extension(s) may cause did-open events for files that aren't actually open in the editor,
   // so this will trigger CA for files not actually open.
-  context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((doc) => {
-    const isVisible = vscode.window.visibleTextEditors.some(editor =>
-      editor.document.uri.toString() === doc.uri.toString()
-    );
-    // The file was not opened by the user (e.g. extension used openTextDocument but not showTextDocument), ignore.
-    if (!isVisible) {
-      return;
-    }
-    fileHandler.handle(doc, outputChannelDep);
-  }));
+  context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((doc) => fileHandler.handle(doc, outputChannelDep)));
   context.subscriptions.push(vscode.workspace.onDidCloseTextDocument(doc => clearCodeActionsMap(doc.uri)));
   // Iterate all open docs, as there is (in general) no did-open event for these.
   for (const doc of vscode.workspace.textDocuments) {


### PR DESCRIPTION
Reverts fabric8-analytics/fabric8-analytics-vscode-extension#811 due to misunderstanding what "visible" means resulting in component analysis not being triggered when we want it to be