### PR TITLE
chore(ci): use current released version in package.json and bump to next patch in stage

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -45,11 +45,11 @@ jobs:
         id: ea_version
         run: |
           # Get the current version from package.json
-          base_version=$(node -p "require('./package.json').version")
+          next_base_version=$(node version patch --no-git-tag-version)
           
           # Get short commit SHA
           short_sha=$(git rev-parse --short HEAD)
-          echo "version=$base_version-ea.$short_sha" >> "$GITHUB_OUTPUT"
+          echo "version=$next_base_version-ea.$short_sha" >> "$GITHUB_OUTPUT"
 
       - name: Update package with EA version
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric8-analytics",
-  "version": "0.10.0",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric8-analytics",
-      "version": "0.10.0",
+      "version": "0.9.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fabric8-analytics",
   "displayName": "Red Hat Dependency Analytics",
   "description": "Provides insights on security vulnerabilities in your application dependencies.",
-  "version": "0.10.0",
+  "version": "0.9.6",
   "author": "Red Hat",
   "publisher": "redhat",
   "preview": true,


### PR DESCRIPTION
All staged versions assume the next version is a patch release e.g. if the latest release is 0.10.0 then staged artifacts will be 0.10.1-ea.<revhash>.
