### PR TITLE
fix: prefix release/tag with v

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
         id: release_version
         run: |
           new_version=$(node -p "require('./package.json').version")
-          echo "version=$new_version" >> "$GITHUB_OUTPUT"
+          echo "version=v$new_version" >> "$GITHUB_OUTPUT"
 
       - name: VSCE package
         run: vsce package --out fabric8-analytics-${{ steps.release_version.outputs.version }}-${{ github.run_number }}.vsix


### PR DESCRIPTION
Closes https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/839

`package.json` contains `0.10.1`, but the version we previously used was the output from `npm version` which already includes the `v` prefix. Hence we have to manually add the prefix now