### PR TITLE
fix: use gradle group:artifact range for diagnostics instead of version range

### DIFF
--- a/src/dependencyAnalysis/analysis.ts
+++ b/src/dependencyAnalysis/analysis.ts
@@ -4,10 +4,9 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import exhort from '@trustification/exhort-javascript-api';
+import exhort, { Options } from '@trustification/exhort-javascript-api';
 import { AnalysisReport } from '@trustification/exhort-api-spec/model/v4/AnalysisReport';
 
-import { globalConfig } from '../config';
 import { isDefined } from '../utils';
 import { IDependencyProvider } from '../dependencyAnalysis/collector';
 import { Uri } from 'vscode';
@@ -191,33 +190,7 @@ class AnalysisResponse {
  * @param provider - The dependency provider of the corresponding ecosystem.
  * @returns A Promise resolving to an AnalysisResponse object.
  */
-async function executeComponentAnalysis(diagnosticFilePath: Uri, provider: IDependencyProvider): Promise<AnalysisResponse> {
-
-  // Define configuration options for the component analysis request
-  const options = {
-    'RHDA_TOKEN': globalConfig.telemetryId,
-    'RHDA_SOURCE': globalConfig.utmSource,
-    'MATCH_MANIFEST_VERSIONS': globalConfig.matchManifestVersions,
-    'EXHORT_PROXY_URL': globalConfig.exhortProxyUrl,
-    'EXHORT_PYTHON_VIRTUAL_ENV': globalConfig.usePythonVirtualEnvironment,
-    'EXHORT_GO_MVS_LOGIC_ENABLED': globalConfig.useGoMVS,
-    'EXHORT_PYTHON_INSTALL_BEST_EFFORTS': globalConfig.enablePythonBestEffortsInstallation,
-    'EXHORT_PIP_USE_DEP_TREE': globalConfig.usePipDepTree,
-    'EXHORT_MVN_PATH': globalConfig.exhortMvnPath,
-    'EXHORT_PREFER_MVNW': globalConfig.exhortPreferMvnw,
-    'EXHORT_MVN_ARGS': globalConfig.exhortMvnArgs,
-    'EXHORT_GRADLE_PATH': globalConfig.exhortGradlePath,
-    'EXHORT_NPM_PATH': globalConfig.exhortNpmPath,
-    'EXHORT_YARN_PATH': globalConfig.exhortYarnPath,
-    'EXHORT_PNPM_PATH': globalConfig.exhortPnpmPath,
-    'EXHORT_GO_PATH': globalConfig.exhortGoPath,
-    'EXHORT_PYTHON3_PATH': globalConfig.exhortPython3Path,
-    'EXHORT_PIP3_PATH': globalConfig.exhortPip3Path,
-    'EXHORT_PYTHON_PATH': globalConfig.exhortPythonPath,
-    'EXHORT_PIP_PATH': globalConfig.exhortPipPath
-  };
-
-  // Execute component analysis
+async function executeComponentAnalysis(diagnosticFilePath: Uri, provider: IDependencyProvider, options: Options): Promise<AnalysisResponse> {
   const componentAnalysisJson = await exhort.componentAnalysis(diagnosticFilePath.fsPath, options);
 
   return new AnalysisResponse(componentAnalysisJson, diagnosticFilePath, provider);

--- a/src/providers/go.mod.ts
+++ b/src/providers/go.mod.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { IDependencyProvider, EcosystemDependencyResolver, IDependency, Dependency } from '../dependencyAnalysis/collector';
+import { IDependencyProvider, EcosystemDependencyResolver, Dependency } from '../dependencyAnalysis/collector';
 import { GOLANG } from '../constants';
 
 /* Please note :: There is an issue with the usage of semverRegex Node.js package in this code.
@@ -25,7 +25,7 @@ export function semVerRegExp(str: string): RegExpExecArray | null {
  * Process entries found in the go.mod file.
  */
 export class DependencyProvider extends EcosystemDependencyResolver implements IDependencyProvider {
-  replacementMap: Map<string, IDependency> = new Map<string, IDependency>();
+  replacementMap: Map<string, Dependency> = new Map<string, Dependency>();
 
   constructor() {
     super(GOLANG); // set ecosystem to 'golang'
@@ -91,9 +91,9 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
    * Parses a line from the file and extracts dependency information.
    * @param line - The line to parse for dependency information.
    * @param index - The index of the line in the file.
-   * @returns An IDependency object representing the parsed dependency or null if no dependency is found.
+   * @returns An Dependency object representing the parsed dependency or null if no dependency is found.
    */
-  private parseLine(line: string, index: number): IDependency | null {
+  private parseLine(line: string, index: number): Dependency | null {
     line = line.split('//')[0]; // Remove comments
     if (!DependencyProvider.clean(line)) { return null; } // Skip lines without dependencies
 
@@ -118,7 +118,7 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
    * @param dep - The dependency to be checked and replaced if necessary.
    * @returns The replaced dependency or the original one if no replacement is found.
    */
-  private applyReplaceMap(dep: IDependency): IDependency {
+  private applyReplaceMap(dep: Dependency): Dependency {
     // invariant: dep.version should be non-null if invariant in parseLine holds.
     // TODO: can we improve the typings around all this a la Required<T>
     return this.replacementMap.get(dep.name.value + '@' + dep.version!.value) || this.replacementMap.get(dep.name.value) || dep;
@@ -127,11 +127,11 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
   /**
    * Extracts dependencies from lines parsed from the file.
    * @param lines - An array of strings representing lines from the file.
-   * @returns An array of IDependency objects representing extracted dependencies.
+   * @returns An array of Dependency objects representing extracted dependencies.
    */
-  private extractDependenciesFromLines(lines: string[]): IDependency[] {
+  private extractDependenciesFromLines(lines: string[]): Dependency[] {
     let isExcluded: boolean = false;
-    const goModDeps: IDependency[] = lines.reduce((dependencies: IDependency[], line: string, index: number) => {
+    const goModDeps: Dependency[] = lines.reduce((dependencies: Dependency[], line: string, index: number) => {
       // ignore excluded dependency lines and scopes
       if (line.includes('exclude')) {
         if (line.includes('(')) {
@@ -160,9 +160,9 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
   /**
    * Collects dependencies from the provided manifest contents.
    * @param contents - The manifest content to collect dependencies from.
-   * @returns A Promise resolving to an array of IDependency objects representing collected dependencies.
+   * @returns A Promise resolving to an array of Dependency objects representing collected dependencies.
    */
-  collect(contents: string): IDependency[] {
+  collect(contents: string): Dependency[] {
     const lines: string[] = DependencyProvider.parseTxtDoc(contents);
     return this.extractDependenciesFromLines(lines);
   }

--- a/src/providers/package.json.ts
+++ b/src/providers/package.json.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as jsonAst from 'json-to-ast';
-import { IDependencyProvider, EcosystemDependencyResolver, IDependency, Dependency } from '../dependencyAnalysis/collector';
+import { IDependencyProvider, EcosystemDependencyResolver, Dependency } from '../dependencyAnalysis/collector';
 import { NPM } from '../constants';
 
 /**
@@ -28,11 +28,11 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
   }
 
   /**
-   * Maps dependencies from the parsed JSON AST to IDependency objects.
+   * Maps dependencies from the parsed JSON AST to Dependency objects.
    * @param jsonAst - The parsed JSON AST to map dependencies from.
-   * @returns An array of IDependency objects representing the dependencies.
+   * @returns An array of Dependency objects representing the dependencies.
    */
-  private mapDependencies(ast: jsonAst.ObjectNode): IDependency[] {
+  private mapDependencies(ast: jsonAst.ObjectNode): Dependency[] {
     return ast.children
       .filter(c => this.classes.includes(c.key.value))
       .flatMap(c => (c.value as jsonAst.ObjectNode).children)
@@ -47,9 +47,9 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
   /**
    * Collects dependencies from the provided manifest contents.
    * @param contents - The manifest content to collect dependencies from.
-   * @returns A Promise resolving to an array of IDependency objects representing collected dependencies.
+   * @returns A Promise resolving to an array of Dependency objects representing collected dependencies.
    */
-  collect(contents: string): IDependency[] {
+  collect(contents: string): Dependency[] {
     let ast: jsonAst.ObjectNode;
 
     try {

--- a/src/providers/pom.xml.ts
+++ b/src/providers/pom.xml.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { IDependencyProvider, EcosystemDependencyResolver, IDependency, Dependency } from '../dependencyAnalysis/collector';
+import { IDependencyProvider, EcosystemDependencyResolver, Dependency } from '../dependencyAnalysis/collector';
 import { parse, DocumentCstNode } from '@xml-tools/parser';
 import { buildAst, accept, XMLElement, XMLDocument } from '@xml-tools/ast';
 import { VERSION_PLACEHOLDER, MAVEN } from '../constants';
@@ -68,11 +68,11 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
   }
 
   /**
-   * Maps XML dependencies to IDependency objects.
+   * Maps XML dependencies to Dependency objects.
    * @param deps - The XML dependencies to map.
-   * @returns An array of IDependency objects representing mapped dependencies.
+   * @returns An array of Dependency objects representing mapped dependencies.
    */
-  private mapDependencies(deps: XMLElement[]): IDependency[] {
+  private mapDependencies(deps: XMLElement[]): Dependency[] {
 
     /**
      * Define a class representing a dependency parsed from the pom.xml file
@@ -100,9 +100,9 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
     }
 
     /**
-     * Converts a valid PomDependency into an IDependency object.
+     * Converts a valid PomDependency into an Dependency object.
      * @param d - A PomDependency instance.
-     * @returns An IDependency object derived from the PomDependency.
+     * @returns An Dependency object derived from the PomDependency.
      */
     function toDependency(d: PomDependency): Dependency {
       const dep: Dependency = new Dependency(
@@ -162,9 +162,9 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
   /**
    * Collects dependencies from the provided manifest contents.
    * @param contents - The manifest content to collect dependencies from.
-   * @returns A Promise resolving to an array of IDependency objects representing collected dependencies.
+   * @returns A Promise resolving to an array of Dependency objects representing collected dependencies.
    */
-  collect(contents: string): IDependency[] {
+  collect(contents: string): Dependency[] {
     const xmlAst: XMLDocument = this.parseXml(contents);
     const deps = this.getXMLDependencies(xmlAst);
     return this.mapDependencies(deps);

--- a/src/providers/requirements.txt.ts
+++ b/src/providers/requirements.txt.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import { PYPI } from '../constants';
-import { IDependencyProvider, EcosystemDependencyResolver, IDependency, Dependency } from '../dependencyAnalysis/collector';
+import { IDependencyProvider, EcosystemDependencyResolver, Dependency } from '../dependencyAnalysis/collector';
 
 /**
  * Process entries found in the requirements.txt file.
@@ -28,9 +28,9 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
    * Parses a line from the file and extracts dependency information.
    * @param line - The line to parse for dependency information.
    * @param index - The index of the line in the file.
-   * @returns An IDependency object representing the parsed dependency or null if no dependency is found.
+   * @returns An Dependency object representing the parsed dependency or null if no dependency is found.
    */
-  private parseLine(line: string, index: number): IDependency | null {
+  private parseLine(line: string, index: number): Dependency | null {
     line = line.split('#')[0]; // Remove comments
     if (!line.trim()) { return null; } // Skip empty lines
 
@@ -48,10 +48,10 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
   /**
    * Extracts dependencies from lines parsed from the file.
    * @param lines - An array of strings representing lines from the file.
-   * @returns An array of IDependency objects representing extracted dependencies.
+   * @returns An array of Dependency objects representing extracted dependencies.
    */
-  private extractDependenciesFromLines(lines: string[]): IDependency[] {
-    return lines.reduce((dependencies: IDependency[], line: string, index: number) => {
+  private extractDependenciesFromLines(lines: string[]): Dependency[] {
+    return lines.reduce((dependencies: Dependency[], line: string, index: number) => {
       const parsedDependency = this.parseLine(line, index);
       if (parsedDependency) {
         dependencies.push(parsedDependency);
@@ -63,9 +63,9 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
   /**
    * Collects dependencies from the provided manifest contents.
    * @param contents - The manifest content to collect dependencies from.
-   * @returns A Promise resolving to an array of IDependency objects representing collected dependencies.
+   * @returns A Promise resolving to an array of Dependency objects representing collected dependencies.
    */
-  collect(contents: string): IDependency[] {
+  collect(contents: string): Dependency[] {
     const lines: string[] = this.parseTxtDoc(contents);
     return this.extractDependenciesFromLines(lines);
   }

--- a/test/dependencyAnalysis/collector.test.ts
+++ b/test/dependencyAnalysis/collector.test.ts
@@ -26,7 +26,7 @@ suite('Dependency Analysis Collector tests', () => {
 
     test('should create map of dependecies', async () => {
 
-        const depMap = new DependencyMap(reqDeps, constants.MAVEN);
+        const depMap = new DependencyMap(reqDeps);
 
         expect(Object.fromEntries(depMap.mapper)).to.eql({
             'mockGroupId1/mockArtifact1': reqDeps[0],
@@ -36,14 +36,14 @@ suite('Dependency Analysis Collector tests', () => {
 
     test('should create empty dependency map', async () => {
 
-        const depMap = new DependencyMap([], constants.MAVEN);
+        const depMap = new DependencyMap([]);
 
         expect(Object.keys(depMap.mapper).length).to.eql(0);
     });
 
     test('should get dependency from dependency map', async () => {
 
-        const depMap = new DependencyMap(reqDeps, constants.MAVEN);
+        const depMap = new DependencyMap(reqDeps);
 
         expect(depMap.get(reqDeps[0].name.value)).to.eq(reqDeps[0]);
         expect(depMap.get(reqDeps[1].name.value)).to.eq(reqDeps[1]);
@@ -63,10 +63,10 @@ suite('Dependency Analysis Collector tests', () => {
 
     test('should create map of dependecies for Gradle', async () => {
 
-        const depMap = new DependencyMap(reqDeps, constants.GRADLE);
+        const depMap = new DependencyMap(reqDeps);
 
         expect(Object.fromEntries(depMap.mapper)).to.eql({
-            'mockGroupId1/mockArtifact1@mockVersion': reqDeps[0],
+            'mockGroupId1/mockArtifact1': reqDeps[0],
             'mockGroupId2/mockArtifact2': reqDeps[1]
         });
     });

--- a/test/providers/build.gradle.test.ts
+++ b/test/providers/build.gradle.test.ts
@@ -33,11 +33,11 @@ dependencies {
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 11, column: 21 } },
                 version: { value: '1.2.3', position: { line: 11, column: 33 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 12, column: 21 } },
                 version: { value: '1.2.3', position: { line: 12, column: 33 } }
             }
         ]);
@@ -60,11 +60,11 @@ dependencies {
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 11, column: 28 } },
                 version: { value: '1.2.3', position: { line: 11, column: 61 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 12, column: 61 } },
                 version: { value: '1.2.3', position: { line: 12, column: 30 } }
             }
         ]);
@@ -88,7 +88,7 @@ dependencies { // a second comment
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 12, column: 83 } },
                 version: { value: '1.2.3', position: { line: 12, column: 30 } }
             }
         ]);
@@ -116,7 +116,7 @@ dependencies {
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 15, column: 21 } },
                 version: { value: '1.2.3', position: { line: 15, column: 33 } }
             }
         ]);
@@ -139,11 +139,11 @@ dependencies {
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 11, column: 31 } },
                 version: { value: '1.2.3', position: { line: 11, column: 43 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 12, column: 44 } },
                 version: { value: '1.2.3', position: { line: 12, column: 86 } }
             }
         ]);
@@ -185,11 +185,11 @@ dependencies {
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 30, column: 21 } },
                 version: { value: '1.2.3', position: { line: 30, column: 44 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 31, column: 28 } },
                 version: { value: '1.2.3', position: { line: 31, column: 66 } }
             }
         ]);
@@ -211,11 +211,11 @@ dependencies { implementation group: "log4j", name: "log4j", version: "1.2.3" }
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 10, column: 32 } },
                 version: { value: '1.2.3', position: { line: 10, column: 44 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 11, column: 39 } },
                 version: { value: '1.2.3', position: { line: 11, column: 72 } }
             }
         ]);
@@ -252,27 +252,27 @@ dependencies
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 10, column: 30 } },
                 version: { value: '1.2.3', position: { line: 10, column: 42 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 12, column: 32 } },
                 version: { value: '1.2.3', position: { line: 12, column: 44 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 15, column: 21 } },
                 version: { value: '1.2.3', position: { line: 15, column: 33 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 18, column: 28 } },
                 version: { value: '1.2.3', position: { line: 18, column: 61 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 22, column: 26 } },
                 version: { value: '1.2.3', position: { line: 22, column: 59 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 25, column: 28 } },
                 version: { value: '1.2.3', position: { line: 25, column: 61 } }
             }
         ]);
@@ -304,15 +304,15 @@ dependencies {
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'commons-codec/commons-codec', position: { line: 0, column: 0 } },
-                context: { value: 'commons-codec:commons-codec:__VERSION__', range: { start: { line: 10, character: 20 }, end: { line: 10, character: 47 } } }
+                name: { value: 'commons-codec/commons-codec', position: { line: 11, column: 21 } },
+                context: { value: 'commons-codec:commons-codec:__VERSION__', range: { start: { line: 11, character: 21 }, end: { line: 11, character: 48 } } }
             },
             {
-                name: { value: 'commons-beanutils/commons-beanutils', position: { line: 0, column: 0 } },
+                name: { value: 'commons-beanutils/commons-beanutils', position: { line: 16, column: 21 } },
                 version: { value: '1.9.4', position: { line: 16, column: 57 } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
+                name: { value: 'log4j/log4j', position: { line: 21, column: 21 } },
                 version: { value: '1.2.3', position: { line: 21, column: 33 } }
             }
         ]);
@@ -335,12 +335,12 @@ dependencies {
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
-                context: { value: 'log4j:log4j:__VERSION__', range: { start: { line: 10, character: 20 }, end: { line: 10, character: 31 } } }
+                name: { value: 'log4j/log4j', position: { line: 11, column: 21 } },
+                context: { value: 'log4j:log4j:__VERSION__', range: { start: { line: 11, character: 21 }, end: { line: 11, character: 32 } } }
             },
             {
-                name: { value: 'log4j/log4j', position: { line: 0, column: 0 } },
-                context: { value: 'name: "log4j", version: "__VERSION__"', range: { start: { line: 11, character: 35 }, end: { line: 11, character: 48 } } }
+                name: { value: 'log4j/log4j', position: { line: 12, column: 28 } },
+                context: { value: 'name: "log4j", version: "__VERSION__"', range: { start: { line: 12, character: 36 }, end: { line: 12, character: 49 } } }
             }
         ]);
     });


### PR DESCRIPTION
If gradle resolves a dependency in build.gradle to a different version than is in build.gradle, previously we would not assign it a range in build.gradle for diagnostics because of the version being different. This change only matches on groupid:artifactid instead to work around this