### PR TITLE
feat: add UI config for setting exhort backend url

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,12 @@
           "markdownDescription": "Enable usage data and errors to be sent to Red Hat servers. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection).",
           "scope": "window"
         },
+        "redHatDependencyAnalytics.backendUrl": {
+          "type": "string",
+          "default": "https://rhda.rhcloud.com",
+          "markdownDescription": "Exhort backend URL to use for stack, component & image analysis.",
+          "scope": "window"
+        },
         "redHatDependencyAnalytics.matchManifestVersions": {
           "type": "boolean",
           "default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ import { Minimatch } from 'minimatch';
  */
 class Config {
   telemetryId: string | undefined;
+  backendUrl: string | undefined;
   stackAnalysisCommand!: string;
   trackRecommendationAcceptanceCommand!: string;
   recommendationsEnabled!: boolean;
@@ -47,6 +48,7 @@ class Config {
   exhortImagePlatform!: string;
   excludePatterns!: Minimatch[];
 
+  private readonly DEFAULT_BACKEND_URL = 'https://rhda.rhcloud.com';
   private readonly DEFAULT_MVN_EXECUTABLE = 'mvn';
   private readonly DEFAULT_GRADLE_EXECUTABLE = 'gradle';
   private readonly DEFAULT_NPM_EXECUTABLE = 'npm';
@@ -97,6 +99,7 @@ class Config {
     this.trackRecommendationAcceptanceCommand = commands.TRACK_RECOMMENDATION_ACCEPTANCE_COMMAND;
     this.recommendationsEnabled = rhdaConfig.recommendations.enabled;
     this.utmSource = GlobalState.UTM_SOURCE;
+    this.backendUrl = rhdaConfig.backendUrl || this.DEFAULT_BACKEND_URL;
     this.exhortProxyUrl = this.getEffectiveHttpProxyUrl();
     /* istanbul ignore next */
     this.matchManifestVersions = rhdaConfig.matchManifestVersions ? 'true' : 'false';
@@ -189,6 +192,7 @@ class Config {
     process.env['VSCEXT_TRUSTIFY_DA_PYTHON_PATH'] = this.exhortPythonPath;
     process.env['VSCEXT_TRUSTIFY_DA_PIP_PATH'] = this.exhortPipPath;
     process.env['VSCEXT_TELEMETRY_ID'] = this.telemetryId;
+    process.env['VSCEXT_TRUSTIFY_DA_BACKEND_URL'] = this.backendUrl;
     process.env['VSCEXT_TRUSTIFY_DA_SYFT_PATH'] = this.exhortSyftPath;
     process.env['VSCEXT_TRUSTIFY_DA_SYFT_CONFIG_PATH'] = this.exhortSyftConfigPath;
     process.env['VSCEXT_TRUSTIFY_DA_SKOPEO_PATH'] = this.exhortSkopeoPath;

--- a/src/dependencyAnalysis/diagnostics.ts
+++ b/src/dependencyAnalysis/diagnostics.ts
@@ -100,6 +100,7 @@ async function performDiagnostics(diagnosticFilePath: Uri, contents: string, pro
   try {
     // Define configuration options for the component analysis request
     const options: Options = {
+      'TRUSTIFY_DA_BACKEND_URL': globalConfig.backendUrl,
       'TRUSTIFY_DA_TOKEN': globalConfig.telemetryId,
       'TRUSTIFY_DA_SOURCE': globalConfig.utmSource,
       'MATCH_MANIFEST_VERSIONS': globalConfig.matchManifestVersions,

--- a/src/imageAnalysis.ts
+++ b/src/imageAnalysis.ts
@@ -16,6 +16,7 @@ import { DepOutputChannel } from './depOutputChannel';
  * Represents options for image analysis.
  */
 interface IOptions extends Options {
+  TRUSTIFY_DA_BACKEND_URL: string | undefined;
   TRUSTIFY_DA_TOKEN: string;
   TRUSTIFY_DA_SOURCE: string;
   TRUSTIFY_DA_SYFT_PATH: string;
@@ -174,6 +175,7 @@ class DockerImageAnalysis {
 
         const options: IOptions = {
           'TRUSTIFY_DA_TOKEN': globalConfig.telemetryId ?? '',
+          'TRUSTIFY_DA_BACKEND_URL': globalConfig.backendUrl,
           'TRUSTIFY_DA_SOURCE': globalConfig.utmSource,
           'TRUSTIFY_DA_SYFT_PATH': globalConfig.exhortSyftPath,
           'TRUSTIFY_DA_SYFT_CONFIG_PATH': globalConfig.exhortSyftConfigPath,

--- a/src/imageAnalysis/diagnostics.ts
+++ b/src/imageAnalysis/diagnostics.ts
@@ -91,6 +91,7 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
 async function performDiagnostics(diagnosticFilePath: Uri, contents: string, provider: IImageProvider) {
   try {
     const options: IOptions = {
+      'TRUSTIFY_DA_BACKEND_URL': globalConfig.backendUrl,
       'TRUSTIFY_DA_TOKEN': globalConfig.telemetryId ?? '',
       'TRUSTIFY_DA_SOURCE': globalConfig.utmSource,
       'TRUSTIFY_DA_SYFT_PATH': globalConfig.exhortSyftPath,

--- a/src/stackAnalysis.ts
+++ b/src/stackAnalysis.ts
@@ -21,6 +21,7 @@ export async function executeStackAnalysis(manifestFilePath: string, outputChann
 
     // set up configuration options for the stack analysis request
     const options: Options = {
+      'TRUSTIFY_DA_BACKEND_URL': globalConfig.backendUrl,
       'TRUSTIFY_DA_TOKEN': globalConfig.telemetryId,
       'TRUSTIFY_DA_SOURCE': globalConfig.utmSource,
       'MATCH_MANIFEST_VERSIONS': globalConfig.matchManifestVersions,

--- a/test/imageAnalysis/collector.test.ts
+++ b/test/imageAnalysis/collector.test.ts
@@ -51,6 +51,7 @@ suite('Image Analysis Collector tests', () => {
     reqImages.forEach(image => image.platform = 'linux/amd64');
 
     const options: IOptions = {
+        'TRUSTIFY_DA_BACKEND_URL': globalConfig.backendUrl,
         'TRUSTIFY_DA_TOKEN': globalConfig.telemetryId ?? '',
         'TRUSTIFY_DA_SOURCE': globalConfig.utmSource,
         'TRUSTIFY_DA_SYFT_PATH': globalConfig.exhortSyftPath,


### PR DESCRIPTION
User-configurable option `redHatDependencyAnalytics.backendUrl`. Defaults to `https://rhda.rhcloud.com`