### PR TITLE
fix: refresh proxy settings before first auto-analysis at startup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,6 +56,10 @@ async function enableExtensionFeatures(context: vscode.ExtensionContext, tokenPr
     visibleEditors = newVisible;
   }));
   context.subscriptions.push(vscode.workspace.onDidCloseTextDocument(doc => clearCodeActionsMap(doc.uri)));
+  // Refresh config now that VS Code's configuration is fully initialized.
+  // The globalConfig singleton was instantiated at module load time, before
+  // workspace settings (e.g. http.proxy) were available.
+  globalConfig.loadData();
   // Iterate all open docs, as there is (in general) no did-open event for these.
   for (const doc of vscode.workspace.textDocuments) {
     fileHandler.handle(tokenProvider, doc, outputChannelDep);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,6 +2,7 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
+import * as vscode from 'vscode';
 
 import { globalConfig } from '../src/config';
 import { GlobalState } from '../src/constants';
@@ -57,6 +58,50 @@ suite('Config module', () => {
     expect(globalConfig.batchConcurrency).to.eq(10);
     expect(globalConfig.continueOnError).to.eq(true);
     expect(globalConfig.batchMetadata).to.eq(true);
+  });
+
+  test('should pick up http.proxy setting after loadData()', async () => {
+    // Given a configured http.proxy setting
+    const httpConfig = vscode.workspace.getConfiguration('http');
+    await httpConfig.update('proxy', 'http://proxy.example.com:8080', vscode.ConfigurationTarget.Global);
+
+    // When loadData() is called
+    globalConfig.loadData();
+
+    // Then the proxy URL should be populated
+    expect(globalConfig.exhortProxyUrl).to.eq('http://proxy.example.com:8080');
+
+    // Cleanup
+    await httpConfig.update('proxy', undefined, vscode.ConfigurationTarget.Global);
+  });
+
+  test('should return empty proxy URL when no proxy is configured', async () => {
+    // Given no proxy is configured
+    const httpConfig = vscode.workspace.getConfiguration('http');
+    await httpConfig.update('proxy', undefined, vscode.ConfigurationTarget.Global);
+
+    // When loadData() is called
+    globalConfig.loadData();
+
+    // Then the proxy URL should be empty
+    expect(globalConfig.exhortProxyUrl).to.eq('');
+  });
+
+  test('should return empty proxy URL when proxySupport is off', async () => {
+    // Given http.proxy is set but proxySupport is off
+    const httpConfig = vscode.workspace.getConfiguration('http');
+    await httpConfig.update('proxy', 'http://proxy.example.com:8080', vscode.ConfigurationTarget.Global);
+    await httpConfig.update('proxySupport', 'off', vscode.ConfigurationTarget.Global);
+
+    // When loadData() is called
+    globalConfig.loadData();
+
+    // Then the proxy URL should be empty
+    expect(globalConfig.exhortProxyUrl).to.eq('');
+
+    // Cleanup
+    await httpConfig.update('proxy', undefined, vscode.ConfigurationTarget.Global);
+    await httpConfig.update('proxySupport', undefined, vscode.ConfigurationTarget.Global);
   });
 
   test('should retrieve telemetry parameters from getTelemetryId and set process environment variables', async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,6 +2,7 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
+import * as vscode from 'vscode';
 
 import { globalConfig } from '../src/config';
 import { GlobalState } from '../src/constants';
@@ -55,6 +56,50 @@ suite('Config module', () => {
     expect(globalConfig.batchConcurrency).to.eq(10);
     expect(globalConfig.continueOnError).to.eq(true);
     expect(globalConfig.batchMetadata).to.eq(true);
+  });
+
+  test('should pick up http.proxy setting after loadData()', async () => {
+    // Given a configured http.proxy setting
+    const httpConfig = vscode.workspace.getConfiguration('http');
+    await httpConfig.update('proxy', 'http://proxy.example.com:8080', vscode.ConfigurationTarget.Global);
+
+    // When loadData() is called
+    globalConfig.loadData();
+
+    // Then the proxy URL should be populated
+    expect(globalConfig.exhortProxyUrl).to.eq('http://proxy.example.com:8080');
+
+    // Cleanup
+    await httpConfig.update('proxy', undefined, vscode.ConfigurationTarget.Global);
+  });
+
+  test('should return empty proxy URL when no proxy is configured', async () => {
+    // Given no proxy is configured
+    const httpConfig = vscode.workspace.getConfiguration('http');
+    await httpConfig.update('proxy', undefined, vscode.ConfigurationTarget.Global);
+
+    // When loadData() is called
+    globalConfig.loadData();
+
+    // Then the proxy URL should be empty
+    expect(globalConfig.exhortProxyUrl).to.eq('');
+  });
+
+  test('should return empty proxy URL when proxySupport is off', async () => {
+    // Given http.proxy is set but proxySupport is off
+    const httpConfig = vscode.workspace.getConfiguration('http');
+    await httpConfig.update('proxy', 'http://proxy.example.com:8080', vscode.ConfigurationTarget.Global);
+    await httpConfig.update('proxySupport', 'off', vscode.ConfigurationTarget.Global);
+
+    // When loadData() is called
+    globalConfig.loadData();
+
+    // Then the proxy URL should be empty
+    expect(globalConfig.exhortProxyUrl).to.eq('');
+
+    // Cleanup
+    await httpConfig.update('proxy', undefined, vscode.ConfigurationTarget.Global);
+    await httpConfig.update('proxySupport', undefined, vscode.ConfigurationTarget.Global);
   });
 
   test('should retrieve telemetry parameters from getTelemetryId and set process environment variables', async () => {


### PR DESCRIPTION
## Summary

- Fix timing race where proxy settings from `http.proxy` are ignored during the first auto-analysis at VS Code startup
- Add `globalConfig.loadData()` call before the document iteration loop in `enableExtensionFeatures()` to refresh config after VS Code is fully initialized
- Add tests verifying proxy setting pickup, no-proxy regression, and `proxySupport: off` behavior

## Test plan

- [x] Unit test: `loadData()` picks up `http.proxy` setting when configured
- [x] Unit test: empty proxy URL when no proxy is configured (no regression)
- [x] Unit test: empty proxy URL when `proxySupport` is `off`
- [x] All 248 tests pass
- [x] Manual QA: verify first auto-analysis succeeds at startup with proxy configured (see TC-3921 QA steps)

Implements [TC-3921](https://redhat.atlassian.net/browse/TC-3921)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-3921]: https://redhat.atlassian.net/browse/TC-3921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ