### PR TITLE
feat: add pyproject.toml support (uv & poetry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ When a specific path is configured in the settings, it takes precedence over the
 | PNPM | `pnpm` | `package.json` |
 | Yarn | `yarn` | `package.json` |
 | Golang | `go` | `go.mod` |
-| Python | `python3/pip3` or `python/pip` | `requirements.txt` |
+| Pip | `python3/pip3` or `python/pip` | `requirements.txt` |
+| Poetry | `poetry` | `pyproject.toml` & `poetry.lock` |
+| UV | `uv` | `pyproject.toml` & `uv.lock` |
 | Gradle | `gradle` | `build.gradle` |
 | Rust | `cargo` | `Cargo.toml` |
 
@@ -166,7 +168,7 @@ Specify glob patterns for manifests to be ignored for background analysis e.g. `
 ## Features
 
 - **Component analysis**
-	<br >Upon opening a manifest file, such as a `pom.xml`, `package.json`, `go.mod`, `requirements.txt`, or `Cargo.toml` file, a vulnerability scan starts the analysis process.
+	<br >Upon opening a manifest file, such as a `pom.xml`, `package.json`, `go.mod`, `requirements.txt`, `pyproject.toml`, or `Cargo.toml` file, a vulnerability scan starts the analysis process.
 	The scan provides immediate inline feedback on detected security vulnerabilities for your application's, and container's dependencies.
 	Such dependencies are appropriately underlined in red, and hovering over it gives you a short summary of the security concern from the available data sources.
 	The summary has the full package name, version number, the amount of known security vulnerabilities, and the highest severity status of said vulnerabilities.
@@ -270,8 +272,8 @@ Specify glob patterns for manifests to be ignored for background analysis e.g. `
 	```
 
 	- **Python**
-	<br >If you want to ignore vulnerabilities for a dependency in a `requirements.txt` file, you must add `# exhortignore` to the end of the line as a comment against the dependency in the manifest file.
-	For example:
+	<br >If you want to ignore vulnerabilities for a dependency in a `requirements.txt` or `pyproject.toml` file, you must add `# exhortignore` to the end of the line as a comment against the dependency in the manifest file.
+	For example, in `requirements.txt`:
 
 	```python
 	requests==2.28.1 # exhortignore
@@ -378,7 +380,7 @@ Specify glob patterns for manifests to be ignored for background analysis e.g. `
 	}
 	```
 
-	For example, creating an alternative file to `requirements.txt`, like `requirements-dev.txt` or `requirements-test.txt` and adding the dev or test dependencies there instead.
+	For example, creating an alternative file to `requirements.txt`, like `requirements-dev.txt` or `requirements-test.txt` and adding the dev or test dependencies there instead. For `pyproject.toml` projects, dev dependencies in `[tool.poetry.group.dev.dependencies]` and `[project.optional-dependencies]` groups are included in the analysis — to exclude them, use `exhortignore` comments.
 
 	For example, placing dependencies under `[dev-dependencies]` or `[build-dependencies]` in a `Cargo.toml` file. Red Hat Dependency Analytics excludes these from analysis and only reports on `[dependencies]`, `[workspace.dependencies]`, and platform-specific sections such as `[target.'cfg(windows)'.dependencies]`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
         "@trustify-da/trustify-da-api-model": "^2.0.7",
-        "@trustify-da/trustify-da-javascript-client": "0.3.0-ea.b8af0f8",
+        "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.dcb2120",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "cli-table3": "^0.6.5",
@@ -472,6 +472,15 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "license": "Apache-2.0",
@@ -608,6 +617,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -854,6 +875,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@oozcitak/dom": {
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
@@ -995,9 +1025,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@trustify-da/trustify-da-javascript-client": {
-      "version": "0.3.0-ea.b8af0f8",
-      "resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-javascript-client/-/trustify-da-javascript-client-0.3.0-ea.b8af0f8.tgz",
-      "integrity": "sha512-V6C1TEZLwsVyHy4gDG2WE9Y/BK/krtgKQzzXLBbb8pTkOOpS5FAI9f3ZBUHgUNqOxp+eYkOr9Lj3XK4Q1MroyQ==",
+      "version": "0.3.0-ea.dcb2120",
+      "resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-javascript-client/-/trustify-da-javascript-client-0.3.0-ea.dcb2120.tgz",
+      "integrity": "sha512-TiYNjOmPruVEa3PJZnhb01JBzpkGe3nQXK0HJD+iriH1qmJxAVX4riPwyh7pT/PDgWShvw3vzLsD5aUi/WQQXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.2",
@@ -1014,8 +1044,9 @@
         "p-limit": "^4.0.0",
         "packageurl-js": "~1.0.2",
         "smol-toml": "^1.6.0",
+        "tree-sitter-gomod": "github:strum355/tree-sitter-go-mod#56326f2ad478892ace58ff247a97d492a3cbcdda",
         "tree-sitter-requirements": "github:Strum355/tree-sitter-requirements#d0261ee76b84253997fe70d7d397e78c006c3801",
-        "web-tree-sitter": "^0.26.6",
+        "web-tree-sitter": "^0.26.7",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -3181,7 +3212,6 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -3481,8 +3511,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -3773,7 +3802,6 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
       "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -3974,7 +4002,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/grapheme-splitter": {
@@ -4038,12 +4065,10 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -4204,7 +4229,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -4964,9 +4988,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "devOptional": true,
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -4976,7 +5001,6 @@
       "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
       "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -5007,7 +5031,6 @@
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5020,7 +5043,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5032,15 +5054,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5053,7 +5073,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5065,8 +5084,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
@@ -6950,7 +6968,6 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -6986,7 +7003,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -7001,7 +7017,6 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -7592,6 +7607,370 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "license": "MIT"
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      }
+    },
+    "node_modules/tree-sitter-gomod": {
+      "version": "1.1.1",
+      "resolved": "git+ssh://git@github.com/strum355/tree-sitter-go-mod.git#56326f2ad478892ace58ff247a97d492a3cbcdda",
+      "integrity": "sha512-NQ/6pAjcjy7cmhQGOMFMXO3mf0PEwwKHXir0yz3h82NX/04Z6Q0FtAq2bAFNZz6bQ+kzX1snJAMRVy+NT9+w5A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp": "^12.2.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/@npmcli/agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/make-fetch-happen": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/node-gyp": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+      "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tree-sitter-gomod/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tree-sitter-python": {
       "version": "0.23.6",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "workspaceContains:**/pom.xml",
     "workspaceContains:**/go.mod",
     "workspaceContains:**/requirements.txt",
+    "workspaceContains:**/pyproject.toml",
     "workspaceContains:**/build.gradle",
     "workspaceContains:**/Cargo.toml",
     "workspaceContains:**/Dockerfile",
@@ -109,6 +110,11 @@
         },
         {
           "command": "rhda.stackAnalysisFromPieBtn",
+          "when": "resourceFilename == pyproject.toml",
+          "group": "navigation"
+        },
+        {
+          "command": "rhda.stackAnalysisFromPieBtn",
           "when": "resourceFilename == build.gradle",
           "group": "navigation"
         },
@@ -142,6 +148,10 @@
         },
         {
           "command": "rhda.stackAnalysisFromExplorer",
+          "when": "resourceFilename == pyproject.toml"
+        },
+        {
+          "command": "rhda.stackAnalysisFromExplorer",
           "when": "resourceFilename == build.gradle"
         },
         {
@@ -169,6 +179,10 @@
         {
           "command": "rhda.stackAnalysisFromEditor",
           "when": "resourceFilename == requirements.txt"
+        },
+        {
+          "command": "rhda.stackAnalysisFromEditor",
+          "when": "resourceFilename == pyproject.toml"
         },
         {
           "command": "rhda.stackAnalysisFromEditor",
@@ -293,6 +307,18 @@
           "type": "string",
           "default": "",
           "description": "Specifies absolute path of cargo executable.",
+          "scope": "window"
+        },
+        "redHatDependencyAnalytics.uv.executable.path": {
+          "type": "string",
+          "default": "",
+          "description": "Specifies absolute path of uv executable.",
+          "scope": "window"
+        },
+        "redHatDependencyAnalytics.poetry.executable.path": {
+          "type": "string",
+          "default": "",
+          "description": "Specifies absolute path of poetry executable.",
           "scope": "window"
         },
         "redHatDependencyAnalytics.python3.executable.path": {
@@ -499,7 +525,7 @@
   "dependencies": {
     "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
     "@trustify-da/trustify-da-api-model": "^2.0.7",
-    "@trustify-da/trustify-da-javascript-client": "0.3.0-ea.b8af0f8",
+    "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.dcb2120",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "^1.0.11",
     "cli-table3": "^0.6.5",

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,8 @@ class Config {
   exhortPythonPath!: string;
   exhortPipPath!: string;
   exhortCargoPath!: string;
+  exhortUvPath!: string;
+  exhortPoetryPath!: string;
   rhdaReportFilePath!: string;
   secrets!: vscode.SecretStorage;
   exhortSyftPath!: string;
@@ -67,6 +69,8 @@ class Config {
   private readonly DEFAULT_PYTHON_EXECUTABLE = 'python';
   private readonly DEFAULT_PIP_EXECUTABLE = 'pip';
   private readonly DEFAULT_CARGO_EXECUTABLE = 'cargo';
+  private readonly DEFAULT_UV_EXECUTABLE = 'uv';
+  private readonly DEFAULT_POETRY_EXECUTABLE = 'poetry';
   private readonly DEFAULT_SYFT_EXECUTABLE = 'syft';
   private readonly DEFAULT_SKOPEO_EXECUTABLE = 'skopeo';
   private readonly DEFAULT_DOCKER_EXECUTABLE = 'docker';
@@ -140,6 +144,8 @@ class Config {
     this.exhortPythonPath = rhdaConfig.get('python.executable.path') || this.DEFAULT_PYTHON_EXECUTABLE;
     this.exhortPipPath = rhdaConfig.get('pip.executable.path') || this.DEFAULT_PIP_EXECUTABLE;
     this.exhortCargoPath = rhdaConfig.get('cargo.executable.path') || this.DEFAULT_CARGO_EXECUTABLE;
+    this.exhortUvPath = rhdaConfig.get('uv.executable.path') || this.DEFAULT_UV_EXECUTABLE;
+    this.exhortPoetryPath = rhdaConfig.get('poetry.executable.path') || this.DEFAULT_POETRY_EXECUTABLE;
     this.exhortSyftPath = rhdaConfig.get('syft.executable.path') || this.DEFAULT_SYFT_EXECUTABLE;
     this.exhortSyftConfigPath = rhdaConfig.get('syft.config.path', '');
     this.exhortSkopeoPath = rhdaConfig.get('skopeo.executable.path') || this.DEFAULT_SKOPEO_EXECUTABLE;
@@ -211,6 +217,8 @@ class Config {
     process.env['VSCEXT_TRUSTIFY_DA_PIP3_PATH'] = this.exhortPip3Path;
     process.env['VSCEXT_TRUSTIFY_DA_PYTHON_PATH'] = this.exhortPythonPath;
     process.env['VSCEXT_TRUSTIFY_DA_PIP_PATH'] = this.exhortPipPath;
+    process.env['VSCEXT_TRUSTIFY_DA_UV_PATH'] = this.exhortUvPath;
+    process.env['VSCEXT_TRUSTIFY_DA_POETRY_PATH'] = this.exhortPoetryPath;
     process.env['VSCEXT_TRUSTIFY_DA_CARGO_PATH'] = this.exhortCargoPath;
     process.env['VSCEXT_TELEMETRY_ID'] = this.telemetryId;
     process.env['VSCEXT_TRUSTIFY_DA_BACKEND_URL'] = this.backendUrl;

--- a/src/dependencyAnalysis/diagnostics.ts
+++ b/src/dependencyAnalysis/diagnostics.ts
@@ -132,6 +132,8 @@ async function performDiagnostics(tokenProvider: TokenProvider, diagnosticFilePa
       'TRUSTIFY_DA_PIP3_PATH': globalConfig.exhortPip3Path,
       'TRUSTIFY_DA_PYTHON_PATH': globalConfig.exhortPythonPath,
       'TRUSTIFY_DA_PIP_PATH': globalConfig.exhortPipPath,
+      'TRUSTIFY_DA_POETRY_PATH': globalConfig.exhortPoetryPath,
+      'TRUSTIFY_DA_UV_PATH': globalConfig.exhortUvPath,
       'TRUSTIFY_DA_CARGO_PATH': globalConfig.exhortCargoPath,
       'TRUSTIFY_DA_LICENSE_CHECK': globalConfig.licenseCheckEnabled.toString()
     };

--- a/src/exhortServices.ts
+++ b/src/exhortServices.ts
@@ -52,6 +52,8 @@ function buildBaseOptions(): Options {
     'TRUSTIFY_DA_PIP3_PATH': globalConfig.exhortPip3Path,
     'TRUSTIFY_DA_PYTHON_PATH': globalConfig.exhortPythonPath,
     'TRUSTIFY_DA_PIP_PATH': globalConfig.exhortPipPath,
+    'TRUSTIFY_DA_POETRY_PATH': globalConfig.exhortPoetryPath,
+    'TRUSTIFY_DA_UV_PATH': globalConfig.exhortUvPath,
     'TRUSTIFY_DA_CARGO_PATH': globalConfig.exhortCargoPath,
     'TRUSTIFY_DA_PROXY_URL': globalConfig.exhortProxyUrl,
   };

--- a/src/fileHandler.ts
+++ b/src/fileHandler.ts
@@ -6,6 +6,7 @@ import { DependencyProvider as PackageJson } from './providers/package.json';
 import { DependencyProvider as PomXml } from './providers/pom.xml';
 import { DependencyProvider as GoMod } from './providers/go.mod';
 import { DependencyProvider as RequirementsTxt } from './providers/requirements.txt';
+import { DependencyProvider as PyprojectToml } from './providers/pyproject.toml';
 import { DependencyProvider as BuildGradle } from './providers/build.gradle';
 import { DependencyProvider as CargoToml } from './providers/cargo-toml';
 import { ImageProvider as Docker } from './providers/docker';
@@ -40,6 +41,11 @@ export class AnalysisMatcher {
       pattern: /^requirements\.txt$/,
       callback: (tokenProvider, path, contents) => { return dependencyDiagnostics.performDiagnostics(tokenProvider, path, contents, new RequirementsTxt()); },
       providerName: 'requirements'
+    },
+    {
+      pattern: /^pyproject\.toml$/,
+      callback: (tokenProvider, path, contents) => { return dependencyDiagnostics.performDiagnostics(tokenProvider, path, contents, new PyprojectToml()); },
+      providerName: 'pyproject'
     },
     {
       pattern: /^build\.gradle$/,

--- a/src/providers/pyproject.toml.ts
+++ b/src/providers/pyproject.toml.ts
@@ -1,0 +1,203 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Red Hat
+ * Licensed under the Apache-2.0 License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import { parseTOML, type AST } from 'toml-eslint-parser';
+import { PYPI } from '../constants';
+import { IDependencyProvider, EcosystemDependencyResolver, Dependency } from '../dependencyAnalysis/collector';
+
+/**
+ * Returns the string name of a TOML key part (bare or quoted).
+ */
+function keyName(part: AST.TOMLBare | AST.TOMLQuoted): string {
+  return 'name' in part ? part.name : part.value;
+}
+
+/**
+ * Parses a PEP 508 dependency string (e.g. "requests>=2.28.1") into name and version specifier.
+ * Returns null if no version specifier is present.
+ */
+function parsePep508(spec: string): { name: string; version: string } | null {
+  // Match package name followed by optional extras, then a version operator and version
+  const match = spec.match(/^([A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?)(\[.*?\])?\s*(~=|===?|[><!]=?)\s*(.+?)(\s*[,;].*)?$/);
+  if (!match) { return null; }
+  return { name: match[1].toLowerCase(), version: match[5].trim() };
+}
+
+/**
+ * Process entries found in pyproject.toml files.
+ * Uses toml-eslint-parser for a full AST with source positions.
+ *
+ * Handles:
+ *   [project]
+ *   dependencies = ["requests>=2.28.1"]        (PEP 621)
+ *
+ *   [project.optional-dependencies]
+ *   dev = ["pytest>=7.0"]                       (PEP 621 extras)
+ *
+ *   [tool.poetry.dependencies]
+ *   requests = "^2.28.1"                        (Poetry string)
+ *   requests = { version = "^2.28.1" }          (Poetry inline table)
+ *
+ *   [tool.poetry.group.<name>.dependencies]
+ *   pytest = "^7.0"                             (Poetry dependency groups)
+ *
+ * The "python" entry in Poetry dependency tables is excluded (it specifies
+ * the Python version constraint, not a PyPI package).
+ */
+export class DependencyProvider extends EcosystemDependencyResolver implements IDependencyProvider {
+
+  constructor() {
+    super(PYPI);
+  }
+
+  private parseToml(contents: string): AST.TOMLProgram {
+    return parseTOML(contents);
+  }
+
+  /**
+   * Converts a TOML AST value location to a 1-based position suitable for diagnostics.
+   * The TOML parser loc is 1-based line, 0-based column; the value loc
+   * includes the opening quote, so we add 2 to the column (+1 skip quote, +1 for 1-based).
+   */
+  private toValuePosition(loc: AST.SourceLocation): { line: number; column: number } {
+    return { line: loc.start.line, column: loc.start.column + 2 };
+  }
+
+  /**
+   * Extracts a version string and its source location from a Poetry-style TOML key-value.
+   * Handles both simple string values (requests = "^2.28.1") and inline tables
+   * (requests = { version = "^2.28.1" }).
+   */
+  private extractPoetryVersion(kv: AST.TOMLKeyValue): { value: string; loc: AST.SourceLocation } | null {
+    if (kv.value.type === 'TOMLValue' && kv.value.kind === 'string') {
+      return { value: String(kv.value.value), loc: kv.value.loc };
+    }
+
+    if (kv.value.type === 'TOMLInlineTable') {
+      const versionKv = kv.value.body
+        .find(inner => keyName(inner.key.keys[0]) === 'version');
+      if (versionKv && versionKv.value.type === 'TOMLValue' && versionKv.value.kind === 'string') {
+        return { value: String(versionKv.value.value), loc: versionKv.value.loc };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Collects dependencies from PEP 621 array entries (e.g. dependencies = ["requests>=2.28.1"]).
+   * Each array element is a PEP 508 dependency string.
+   */
+  private collectPep621Array(arrayNode: AST.TOMLArray): Dependency[] {
+    const deps: Dependency[] = [];
+    for (const element of arrayNode.elements) {
+      if (element.type === 'TOMLValue' && element.kind === 'string') {
+        const specString = String(element.value);
+        const parsed = parsePep508(specString);
+        if (!parsed) { continue; }
+        // Find the version offset within the spec string so the diagnostic
+        // underlines the version, not the entire dependency specifier.
+        const versionOffset = specString.lastIndexOf(parsed.version);
+        if (versionOffset < 0) { continue; }
+        const dep = new Dependency({ value: parsed.name, position: { line: 0, column: 0 } });
+        dep.version = {
+          value: parsed.version,
+          position: {
+            line: element.loc.start.line,
+            column: element.loc.start.column + 2 + versionOffset,
+          },
+        };
+        deps.push(dep);
+      }
+    }
+    return deps;
+  }
+
+  /**
+   * Collects dependencies from a Poetry-style dependency table where each
+   * key-value pair represents a package (e.g. requests = "^2.28.1").
+   * Excludes the "python" entry which specifies the interpreter version constraint.
+   */
+  private collectPoetryTable(kvs: AST.TOMLKeyValue[]): Dependency[] {
+    const deps: Dependency[] = [];
+    for (const kv of kvs) {
+      const localName = keyName(kv.key.keys[0]);
+      if (localName === 'python') { continue; }
+      const version = this.extractPoetryVersion(kv);
+      if (!version) { continue; }
+      const dep = new Dependency({ value: localName.toLowerCase(), position: { line: 0, column: 0 } });
+      dep.version = { value: version.value, position: this.toValuePosition(version.loc) };
+      deps.push(dep);
+    }
+    return deps;
+  }
+
+  /**
+   * Checks whether a resolved key matches a specific key path.
+   */
+  private keyPathEquals(resolvedKey: (string | number)[], ...expected: string[]): boolean {
+    if (resolvedKey.length !== expected.length) { return false; }
+    return expected.every((seg, i) => resolvedKey[i] === seg);
+  }
+
+  /**
+   * Checks whether a resolved key matches a Poetry dependency group table:
+   * [tool.poetry.group.<name>.dependencies]
+   */
+  private isPoetryGroupDepsTable(resolvedKey: (string | number)[]): boolean {
+    return resolvedKey.length === 5
+      && resolvedKey[0] === 'tool'
+      && resolvedKey[1] === 'poetry'
+      && resolvedKey[2] === 'group'
+      && resolvedKey[4] === 'dependencies';
+  }
+
+  collect(contents: string): Dependency[] {
+    let ast: AST.TOMLProgram;
+    try {
+      ast = this.parseToml(contents);
+    } catch {
+      return [];
+    }
+
+    const dependencies: Dependency[] = [];
+    const topLevel = ast.body[0];
+
+    for (const node of topLevel.body) {
+      if (node.type === 'TOMLTable') {
+        // [project] — look for "dependencies" key-value with an array value
+        if (this.keyPathEquals(node.resolvedKey, 'project')) {
+          for (const kv of node.body) {
+            if (keyName(kv.key.keys[0]) === 'dependencies' && kv.value.type === 'TOMLArray') {
+              dependencies.push(...this.collectPep621Array(kv.value));
+            }
+          }
+        }
+
+        // [project.optional-dependencies] — each key maps to an array of PEP 508 strings
+        if (this.keyPathEquals(node.resolvedKey, 'project', 'optional-dependencies')) {
+          for (const kv of node.body) {
+            if (kv.value.type === 'TOMLArray') {
+              dependencies.push(...this.collectPep621Array(kv.value));
+            }
+          }
+        }
+
+        // [tool.poetry.dependencies] — Poetry-style key-value pairs
+        if (this.keyPathEquals(node.resolvedKey, 'tool', 'poetry', 'dependencies')) {
+          dependencies.push(...this.collectPoetryTable(node.body));
+        }
+
+        // [tool.poetry.group.<name>.dependencies] — Poetry dependency groups
+        if (this.isPoetryGroupDepsTable(node.resolvedKey)) {
+          dependencies.push(...this.collectPoetryTable(node.body));
+        }
+      }
+    }
+
+    return dependencies;
+  }
+}

--- a/src/rhda.ts
+++ b/src/rhda.ts
@@ -27,6 +27,7 @@ const GO_MOD = 'go.mod';
 const POM_XML = 'pom.xml';
 const PACKAGE_JSON = 'package.json';
 const REQUIREMENTS_TXT = 'requirements.txt';
+const PYPROJECT_TOML = 'pyproject.toml';
 const BUILD_GRADLE = 'build.gradle';
 const CARGO_TOML = 'Cargo.toml';
 const DOCKERFILE = 'Dockerfile';
@@ -48,7 +49,7 @@ function getFileType(filePath: string): supportedFileTypes | undefined {
   else if (basename === PACKAGE_JSON) {
     return 'npm';
   }
-  else if (basename === REQUIREMENTS_TXT) {
+  else if (basename === REQUIREMENTS_TXT || basename === PYPROJECT_TOML) {
     return 'python';
   }
   else if (basename === BUILD_GRADLE) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -45,6 +45,8 @@ suite('Config module', () => {
     expect(globalConfig.exhortPip3Path).to.eq('pip3');
     expect(globalConfig.exhortPythonPath).to.eq('python');
     expect(globalConfig.exhortPipPath).to.eq('pip');
+    expect(globalConfig.exhortUvPath).to.eq('uv');
+    expect(globalConfig.exhortPoetryPath).to.eq('poetry');
     expect(globalConfig.exhortSyftPath).to.eq('syft');
     expect(globalConfig.exhortSyftConfigPath).to.eq('');
     expect(globalConfig.exhortSkopeoPath).to.eq('skopeo');
@@ -91,6 +93,8 @@ suite('Config module', () => {
     expect(process.env['VSCEXT_TRUSTIFY_DA_PIP3_PATH']).to.eq('pip3');
     expect(process.env['VSCEXT_TRUSTIFY_DA_PYTHON_PATH']).to.eq('python');
     expect(process.env['VSCEXT_TRUSTIFY_DA_PIP_PATH']).to.eq('pip');
+    expect(process.env['VSCEXT_TRUSTIFY_DA_UV_PATH']).to.eq('uv');
+    expect(process.env['VSCEXT_TRUSTIFY_DA_POETRY_PATH']).to.eq('poetry');
     expect(process.env['VSCEXT_TELEMETRY_ID']).to.equal(mockId);
     expect(process.env['VSCEXT_TRUSTIFY_DA_SYFT_PATH']).to.equal('syft');
     expect(process.env['VSCEXT_TRUSTIFY_DA_SYFT_CONFIG_PATH']).to.equal('');

--- a/test/providers/pyproject.toml.test.ts
+++ b/test/providers/pyproject.toml.test.ts
@@ -1,0 +1,276 @@
+'use strict';
+
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import * as chaiSubset from 'chai-subset';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+chai.use(chaiSubset);
+
+import { DependencyProvider } from '../../src/providers/pyproject.toml';
+
+let dependencyProvider: DependencyProvider;
+suite('Python PyPi pyproject.toml parser tests', () => {
+    /** Verifies that an empty pyproject.toml returns no dependencies. */
+    test('tests empty pyproject.toml', async () => {
+        const deps = dependencyProvider.collect(``);
+        expect(deps).is.eql([]);
+    });
+
+    /** Verifies that invalid TOML content returns no dependencies instead of throwing. */
+    test('tests invalid TOML returns empty array', async () => {
+        const deps = dependencyProvider.collect(`this is not valid toml [[[`);
+        expect(deps).is.eql([]);
+    });
+
+    /** Verifies parsing of PEP 621 [project.dependencies] with various version operators. */
+    test('tests PEP 621 [project.dependencies]', async () => {
+        // Given a pyproject.toml with PEP 621 dependencies
+        const deps = dependencyProvider.collect(
+`[project]
+dependencies = [
+    "requests>=2.28.1",
+    "flask==2.3.0",
+    "numpy~=1.24",
+]`);
+
+        // Then all three dependencies are extracted with correct version positions
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'requests', position: { line: 0, column: 0 } },
+                version: { value: '2.28.1', position: { line: 3, column: 16 } }
+            },
+            {
+                name: { value: 'flask', position: { line: 0, column: 0 } },
+                version: { value: '2.3.0', position: { line: 4, column: 13 } }
+            },
+            {
+                name: { value: 'numpy', position: { line: 0, column: 0 } },
+                version: { value: '1.24', position: { line: 5, column: 13 } }
+            }
+        ]);
+        expect(deps.length).to.equal(3);
+    });
+
+    /** Verifies parsing of Poetry-style string dependencies. */
+    test('tests Poetry [tool.poetry.dependencies]', async () => {
+        // Given a pyproject.toml with Poetry-style dependencies
+        const deps = dependencyProvider.collect(
+`[tool.poetry.dependencies]
+python = "^3.9"
+requests = "^2.28.1"
+flask = "^2.3.0"`);
+
+        // Then python is excluded and version positions point inside the quoted value
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'requests', position: { line: 0, column: 0 } },
+                version: { value: '^2.28.1', position: { line: 3, column: 13 } }
+            },
+            {
+                name: { value: 'flask', position: { line: 0, column: 0 } },
+                version: { value: '^2.3.0', position: { line: 4, column: 10 } }
+            }
+        ]);
+        expect(deps.length).to.equal(2);
+    });
+
+    /** Verifies that the "python" version constraint in Poetry tables is excluded. */
+    test('tests python version constraint is excluded from Poetry dependencies', async () => {
+        const deps = dependencyProvider.collect(
+`[tool.poetry.dependencies]
+python = "^3.9"
+requests = "^2.28.1"`);
+        expect(deps.length).to.equal(1);
+        expect(deps[0].name.value).to.equal('requests');
+    });
+
+    /** Verifies parsing of PEP 621 optional-dependencies groups. */
+    test('tests [project.optional-dependencies] groups', async () => {
+        // Given a pyproject.toml with optional-dependencies groups
+        const deps = dependencyProvider.collect(
+`[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "black>=23.0",
+]
+docs = [
+    "sphinx>=6.0",
+]`);
+
+        // Then dependencies from all groups are collected with correct positions
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'pytest', position: { line: 0, column: 0 } },
+                version: { value: '7.0', position: { line: 3, column: 14 } }
+            },
+            {
+                name: { value: 'black', position: { line: 0, column: 0 } },
+                version: { value: '23.0', position: { line: 4, column: 13 } }
+            },
+            {
+                name: { value: 'sphinx', position: { line: 0, column: 0 } },
+                version: { value: '6.0', position: { line: 7, column: 14 } }
+            }
+        ]);
+        expect(deps.length).to.equal(3);
+    });
+
+    /** Verifies parsing of Poetry inline table dependencies with version key. */
+    test('tests Poetry inline table dependencies', async () => {
+        const deps = dependencyProvider.collect(
+`[tool.poetry.dependencies]
+requests = { version = "^2.28.1", optional = true }`);
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'requests', position: { line: 0, column: 0 } },
+                version: { value: '^2.28.1' }
+            }
+        ]);
+        expect(deps.length).to.equal(1);
+    });
+
+    /** Verifies parsing of Poetry dependency group tables. */
+    test('tests Poetry [tool.poetry.group.dev.dependencies]', async () => {
+        // Given a pyproject.toml with Poetry dependency group
+        const deps = dependencyProvider.collect(
+`[tool.poetry.group.dev.dependencies]
+pytest = "^7.0"
+mypy = "^1.0"`);
+
+        // Then dependencies are collected with positions inside the quoted values
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'pytest', position: { line: 0, column: 0 } },
+                version: { value: '^7.0', position: { line: 2, column: 11 } }
+            },
+            {
+                name: { value: 'mypy', position: { line: 0, column: 0 } },
+                version: { value: '^1.0', position: { line: 3, column: 9 } }
+            }
+        ]);
+        expect(deps.length).to.equal(2);
+    });
+
+    /** Verifies that TOML comments do not affect parsing. */
+    test('tests TOML comments are handled correctly', async () => {
+        const deps = dependencyProvider.collect(
+`[project]
+# This is a comment
+dependencies = [
+    # commented dependency
+    "requests>=2.28.1", # inline comment
+    "flask==2.3.0",
+]`);
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'requests', position: { line: 0, column: 0 } },
+                version: { value: '2.28.1' }
+            },
+            {
+                name: { value: 'flask', position: { line: 0, column: 0 } },
+                version: { value: '2.3.0' }
+            }
+        ]);
+        expect(deps.length).to.equal(2);
+    });
+
+    /** Verifies that version positions (line/column) are accurate for inline diagnostics. */
+    test('tests dependency positions are accurate for diagnostics placement', async () => {
+        // Given a pyproject.toml with known positions
+        const contents =
+`[project]
+dependencies = [
+    "requests>=2.28.1",
+]
+
+[tool.poetry.dependencies]
+flask = "^2.3.0"`;
+
+        // When collecting dependencies
+        const deps = dependencyProvider.collect(contents);
+
+        // Then PEP 621 dependency position points to the version within the spec string
+        const requestsDep = deps.find(d => d.name.value === 'requests');
+        expect(requestsDep).to.not.be.undefined;
+        expect(requestsDep!.version!.position.line).to.equal(3);
+        expect(requestsDep!.version!.position.column).to.equal(16);
+
+        // Then Poetry dependency position points inside the quoted string value
+        const flaskDep = deps.find(d => d.name.value === 'flask');
+        expect(flaskDep).to.not.be.undefined;
+        expect(flaskDep!.version!.position.line).to.equal(7);
+        expect(flaskDep!.version!.position.column).to.equal(10);
+    });
+
+    /** Verifies that dependencies without version specifiers are skipped. */
+    test('tests PEP 621 dependencies without version specifiers are skipped', async () => {
+        const deps = dependencyProvider.collect(
+`[project]
+dependencies = [
+    "requests",
+    "flask>=2.3.0",
+]`);
+        expect(deps.length).to.equal(1);
+        expect(deps[0].name.value).to.equal('flask');
+    });
+
+    /** Verifies that package names are lowercased per Python packaging convention. */
+    test('tests package names are lowercased', async () => {
+        const deps = dependencyProvider.collect(
+`[project]
+dependencies = [
+    "Flask>=2.3.0",
+    "NumPy~=1.24",
+]`);
+        expect(deps[0].name.value).to.equal('flask');
+        expect(deps[1].name.value).to.equal('numpy');
+    });
+
+    /** Verifies that PEP 621 dependencies with extras markers are parsed correctly. */
+    test('tests PEP 621 dependencies with extras', async () => {
+        const deps = dependencyProvider.collect(
+`[project]
+dependencies = [
+    "requests[security]>=2.28.1",
+]`);
+        expect(deps.length).to.equal(1);
+        expect(deps[0].name.value).to.equal('requests');
+        expect(deps[0].version!.value).to.equal('2.28.1');
+    });
+
+    /** Verifies that a combined PEP 621 and Poetry file collects all dependencies. */
+    test('tests mixed PEP 621 and Poetry sections', async () => {
+        const deps = dependencyProvider.collect(
+`[project]
+dependencies = [
+    "requests>=2.28.1",
+]
+
+[tool.poetry.dependencies]
+flask = "^2.3.0"
+
+[tool.poetry.group.test.dependencies]
+pytest = "^7.0"`);
+        expect(deps.length).to.equal(3);
+        const names = deps.map(d => d.name.value);
+        expect(names).to.include.members(['requests', 'flask', 'pytest']);
+    });
+
+    /** Verifies that a pyproject.toml with no dependency sections returns empty. */
+    test('tests pyproject.toml with no dependency sections', async () => {
+        const deps = dependencyProvider.collect(
+`[project]
+name = "my-project"
+version = "1.0.0"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"`);
+        expect(deps).is.eql([]);
+    });
+
+}).beforeEach(() => {
+    dependencyProvider = new DependencyProvider();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,13 @@
     "target": "esnext",
     "lib": ["es2022"],
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "outDir": "out",
     "sourceMap": true,
     "rootDir": ".",
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "types": ["node", "mocha"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- Add a new `DependencyProvider` for `pyproject.toml` files, supporting both PEP 621 (`[project.dependencies]`, `[project.optional-dependencies]`) and Poetry (`[tool.poetry.dependencies]`, `[tool.poetry.group.<name>.dependencies]`) formats
- Add VS Code settings for `uv` and `poetry` binary paths (`redHatDependencyAnalytics.uv.executable.path`, `redHatDependencyAnalytics.poetry.executable.path`), propagated to the JS client via `VSCEXT_TRUSTIFY_DA_UV_PATH` / `VSCEXT_TRUSTIFY_DA_POETRY_PATH` environment variables
- Register `pyproject.toml` in activation events, file handler, menus, and `rhda.ts` file type detection

Resolves: [TC-3852](https://redhat.atlassian.net/browse/TC-3852)

## Test plan
- [x] 13 unit tests covering PEP 621, Poetry, inline tables, dependency groups, extras, comments, position accuracy, edge cases
- [ ] Manual testing with `test-workspace/python-uv/pyproject.toml` (PEP 621 / hatchling)
- [ ] Manual testing with `test-workspace/python-poetry/pyproject.toml` (Poetry)
- [ ] Verify `uv.executable.path` and `poetry.executable.path` settings appear in VS Code settings UI
- [ ] Verify diagnostic underlines appear at correct positions for dependency versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-3852]: https://redhat.atlassian.net/browse/TC-3852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ