### PR TITLE
feat: add Generate SBOM command to VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ Specify glob patterns for manifests to be ignored for background analysis e.g. `
 	The command detects the workspace root, discovers all sub-packages (via `pnpm-workspace.yaml`, `package.json` workspaces, or `cargo metadata`), generates SBOMs in parallel, and produces a combined analysis report.
 	Existing exclude patterns from `redHatDependencyAnalytics.exclude` are automatically applied to workspace package discovery.
 
+- **Generate SBOM**
+	<br >Generate a CycloneDX SBOM from a supported manifest file using the _RHDA: Generate SBOM_ command.
+	The command is available from the Command Palette (Ctrl+Shift+P / Cmd+Shift+P), editor title bar, editor context menu, and explorer context menu when a supported manifest file is open or selected.
+	After generation, a Save File dialog lets you choose where to save the resulting `bom.json` file.
+
 - **Excluding dependencies with `exhortignore`**
 	<br >You can exclude a package from analysis by marking the package for exclusion.
 	How you exclude a package varies based on the your project's language:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
         "@trustify-da/trustify-da-api-model": "^2.0.7",
-        "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.dcb2120",
+        "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.2e5fe72",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "cli-table3": "^0.6.5",
@@ -1025,9 +1025,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@trustify-da/trustify-da-javascript-client": {
-      "version": "0.3.0-ea.dcb2120",
-      "resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-javascript-client/-/trustify-da-javascript-client-0.3.0-ea.dcb2120.tgz",
-      "integrity": "sha512-TiYNjOmPruVEa3PJZnhb01JBzpkGe3nQXK0HJD+iriH1qmJxAVX4riPwyh7pT/PDgWShvw3vzLsD5aUi/WQQXg==",
+      "version": "0.3.0-ea.2e5fe72",
+      "resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-javascript-client/-/trustify-da-javascript-client-0.3.0-ea.2e5fe72.tgz",
+      "integrity": "sha512-AzAydfEGjAClvIA3SUTl5KphvtqBLncJTd6V+ydgwvhmYdxIkfeTqmiyvD1aZBwZqwDkeMRNtdvUvG5/kqfFDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -618,7 +618,7 @@
   "dependencies": {
     "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
     "@trustify-da/trustify-da-api-model": "^2.0.7",
-    "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.dcb2120",
+    "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.2e5fe72",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "^1.0.11",
     "cli-table3": "^0.6.5",

--- a/package.json
+++ b/package.json
@@ -298,6 +298,10 @@
         {
           "command": "rhda.stackAnalysisFromExplorer",
           "when": "false"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == Cargo.toml"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -135,31 +135,7 @@
         },
         {
           "command": "rhda.generateSbom",
-          "when": "resourceFilename == pom.xml"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == package.json"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == go.mod"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == requirements.txt"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == pyproject.toml"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == build.gradle"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == Cargo.toml"
+          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == Cargo.toml"
         }
       ],
       "explorer/context": [
@@ -197,31 +173,7 @@
         },
         {
           "command": "rhda.generateSbom",
-          "when": "resourceFilename == package.json"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == pom.xml"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == go.mod"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == requirements.txt"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == pyproject.toml"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == build.gradle"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == Cargo.toml"
+          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == Cargo.toml"
         }
       ],
       "editor/context": [
@@ -259,31 +211,7 @@
         },
         {
           "command": "rhda.generateSbom",
-          "when": "resourceFilename == package.json"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == pom.xml"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == go.mod"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == requirements.txt"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == pyproject.toml"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == build.gradle"
-        },
-        {
-          "command": "rhda.generateSbom",
-          "when": "resourceFilename == Cargo.toml"
+          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == Cargo.toml"
         }
       ],
       "commandPalette": [

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
         "command": "rhda.stackAnalysisBatch",
         "title": "Red Hat Dependency Analytics Batch Report (Workspace)...",
         "category": "Red Hat Dependency Analytics"
+      },
+      {
+        "command": "rhda.generateSbom",
+        "title": "RHDA: Generate SBOM",
+        "category": "Red Hat Dependency Analytics"
       }
     ],
     "menus": {
@@ -127,6 +132,34 @@
           "command": "rhda.stackAnalysisFromPieBtn",
           "when": "resourceFilename == Dockerfile || resourceFilename == Containerfile",
           "group": "navigation"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == pom.xml"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == package.json"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == go.mod"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == requirements.txt"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == pyproject.toml"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == build.gradle"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == Cargo.toml"
         }
       ],
       "explorer/context": [
@@ -161,6 +194,34 @@
         {
           "command": "rhda.stackAnalysisFromExplorer",
           "when": "resourceFilename == Dockerfile || resourceFilename == Containerfile"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == package.json"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == pom.xml"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == go.mod"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == requirements.txt"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == pyproject.toml"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == build.gradle"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == Cargo.toml"
         }
       ],
       "editor/context": [
@@ -195,6 +256,34 @@
         {
           "command": "rhda.stackAnalysisFromEditor",
           "when": "resourceFilename == Dockerfile || resourceFilename == Containerfile"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == package.json"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == pom.xml"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == go.mod"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == requirements.txt"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == pyproject.toml"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == build.gradle"
+        },
+        {
+          "command": "rhda.generateSbom",
+          "when": "resourceFilename == Cargo.toml"
         }
       ],
       "commandPalette": [

--- a/src/batchAnalysis.ts
+++ b/src/batchAnalysis.ts
@@ -3,7 +3,8 @@
 import * as vscode from 'vscode';
 
 import { StatusMessages, Titles } from './constants';
-import { buildBaseOptions, batchStackAnalysisService, BatchOptions } from './exhortServices';
+import { buildBaseOptions, batchStackAnalysisService } from './exhortServices';
+import { Options } from '@trustify-da/trustify-da-javascript-client';
 import { globalConfig } from './config';
 import { updateCurrentWebviewPanel } from './rhda';
 import { buildLogErrorMessage } from './utils';
@@ -22,7 +23,7 @@ export async function executeBatchStackAnalysis(tokenProvider: TokenProvider, wo
   return await vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: Titles.EXT_TITLE }, async p => {
     p.report({ message: StatusMessages.WIN_ANALYZING_DEPENDENCIES });
 
-    const options: BatchOptions = {
+    const options: Options = {
       ...buildBaseOptions(),
       'TRUSTIFY_DA_TOKEN': await tokenProvider.getToken() ?? '',
       'batchConcurrency': globalConfig.batchConcurrency,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,3 +12,4 @@ export const STACK_LOGS_COMMAND = 'rhda.stackLogs';
 export const TRACK_RECOMMENDATION_ACCEPTANCE_COMMAND = 'rhda.trackRecommendationAcceptance';
 export const LLM_MODELS_ANALYSIS_REPORT = 'rhda.llmModelsAnalysisReport';
 export const STACK_ANALYSIS_BATCH_COMMAND = 'rhda.stackAnalysisBatch';
+export const GENERATE_SBOM_COMMAND = 'rhda.generateSbom';

--- a/src/exhortServices.ts
+++ b/src/exhortServices.ts
@@ -8,24 +8,6 @@ import { AnalysisReport } from '@trustify-da/trustify-da-api-model/model/v5/Anal
 import { globalConfig } from './config';
 
 /**
- * Options for batch analysis.
- * The upstream Options type only allows string values, but the JS client's
- * stackAnalysisBatch() also accepts number, boolean, and string[] fields.
- *
- * Batch-specific fields below use camelCase property names as read by the
- * client's resolve helpers (e.g. opts.batchConcurrency first). The
- * TRUSTIFY_DA_* env var names are fallbacks via process.env, not the opts
- * keys for those settings—do not rename batch fields to match env names.
- */
-export interface BatchOptions {
-  [key: string]: string | number | boolean | string[] | undefined;
-  batchConcurrency?: number;
-  continueOnError?: boolean;
-  batchMetadata?: boolean;
-  workspaceDiscoveryIgnore?: string[];
-}
-
-/**
  * Builds the common options object from globalConfig, shared across
  * stack analysis, batch analysis, and token validation calls.
  */
@@ -135,20 +117,12 @@ async function tokenValidationService(options: Options, source: string): Promise
  * @param options Additional options for the analysis including batch-specific settings.
  * @returns A promise resolving to the batch stack analysis report in HTML format.
  */
-async function batchStackAnalysisService(workspaceRoot: string, options: BatchOptions): Promise<string> {
-  const result = await exhort.stackAnalysisBatch(workspaceRoot, true, options);
-  // When batchMetadata is enabled, the result is { analysis, metadata };
-  // otherwise it's the raw HTML string
-  if (typeof result === 'string') {
-    return result;
+async function batchStackAnalysisService(workspaceRoot: string, options: Options): Promise<string> {
+  if (options.batchMetadata) {
+    const { analysis } = await exhort.stackAnalysisBatch(workspaceRoot, true, { ...options, batchMetadata: true });
+    return analysis;
   }
-  if ('analysis' in result) {
-    if (typeof result.analysis !== 'string') {
-      throw new Error('Unexpected non-HTML response from stackAnalysisBatch');
-    }
-    return result.analysis;
-  }
-  throw new Error('Unexpected non-HTML response from stackAnalysisBatch');
+  return await exhort.stackAnalysisBatch(workspaceRoot, true, { ...options, batchMetadata: false });
 }
 
 /**

--- a/src/exhortServices.ts
+++ b/src/exhortServices.ts
@@ -136,15 +136,19 @@ async function tokenValidationService(options: Options, source: string): Promise
  * @returns A promise resolving to the batch stack analysis report in HTML format.
  */
 async function batchStackAnalysisService(workspaceRoot: string, options: BatchOptions): Promise<string> {
-  // Cast exhort to access stackAnalysisBatch which exists at runtime but
-  // is not yet in the published type definitions
-  const result = await (exhort as any).stackAnalysisBatch(workspaceRoot, true, options);
+  const result = await exhort.stackAnalysisBatch(workspaceRoot, true, options);
   // When batchMetadata is enabled, the result is { analysis, metadata };
   // otherwise it's the raw HTML string
-  if (result && typeof result === 'object' && 'analysis' in result) {
+  if (typeof result === 'string') {
+    return result;
+  }
+  if ('analysis' in result) {
+    if (typeof result.analysis !== 'string') {
+      throw new Error('Unexpected non-HTML response from stackAnalysisBatch');
+    }
     return result.analysis;
   }
-  return result;
+  throw new Error('Unexpected non-HTML response from stackAnalysisBatch');
 }
 
 /**
@@ -154,9 +158,7 @@ async function batchStackAnalysisService(workspaceRoot: string, options: BatchOp
  * @returns A promise resolving to the SBOM as a parsed JSON object.
  */
 async function generateSbomService(pathToManifest: string, options: Options): Promise<object> {
-  // Cast exhort to access generateSbom which exists at runtime but
-  // is not yet in the published type definitions
-  return await (exhort as any).generateSbom(pathToManifest, options);
+  return await exhort.generateSbom(pathToManifest, options);
 }
 
 export { buildBaseOptions, imageAnalysisService, stackAnalysisService, batchStackAnalysisService, tokenValidationService, parseImageReference, generateSbomService };

--- a/src/exhortServices.ts
+++ b/src/exhortServices.ts
@@ -147,4 +147,16 @@ async function batchStackAnalysisService(workspaceRoot: string, options: BatchOp
   return result;
 }
 
-export { buildBaseOptions, imageAnalysisService, stackAnalysisService, batchStackAnalysisService, tokenValidationService, parseImageReference };
+/**
+ * Generates a CycloneDX SBOM for the given manifest file.
+ * @param pathToManifest The path to the manifest file.
+ * @param options Additional options for generation.
+ * @returns A promise resolving to the SBOM as a parsed JSON object.
+ */
+async function generateSbomService(pathToManifest: string, options: Options): Promise<object> {
+  // Cast exhort to access generateSbom which exists at runtime but
+  // is not yet in the published type definitions
+  return await (exhort as any).generateSbom(pathToManifest, options);
+}
+
+export { buildBaseOptions, imageAnalysisService, stackAnalysisService, batchStackAnalysisService, tokenValidationService, parseImageReference, generateSbomService };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { Language, Parser, Query } from 'web-tree-sitter';
 import { getValidAccessToken, performOIDCAuthorizationFlow } from './oidcAuthentication';
 import { TokenProvider, VSCodeTokenProvider } from './tokenProvider';
 import { executeBatchStackAnalysis } from './batchAnalysis';
+import { generateSbomService, buildBaseOptions } from './exhortServices';
 
 export let outputChannelDep: DepOutputChannel;
 
@@ -318,6 +319,7 @@ async function enableExtensionFeatures(context: vscode.ExtensionContext, tokenPr
   );
 
   registerStackAnalysisCommands(context, tokenProvider);
+  registerGenerateSbomCommand(context);
 
   const disposableBatchAnalysisCommand = vscode.commands.registerCommand(
     commands.STACK_ANALYSIS_BATCH_COMMAND,
@@ -516,6 +518,58 @@ function showRHRepositoryRecommendationNotification() {
     'This ensures that the applied dependencies work correctly. ' +
     `Learn how to add the repository: [Click here](${REDHAT_MAVEN_REPOSITORY_DOCUMENTATION_URL})`;
   vscode.window.showWarningMessage(msg);
+}
+
+/**
+ * Registers the Generate SBOM command.
+ * @param context - The extension context.
+ */
+function registerGenerateSbomCommand(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand(
+    commands.GENERATE_SBOM_COMMAND,
+    async (uri?: vscode.Uri) => {
+      const fileUri = uri || vscode.window.activeTextEditor?.document.uri;
+      if (!fileUri) {
+        vscode.window.showErrorMessage('No manifest file selected. Open or select a supported manifest file.');
+        return;
+      }
+
+      const filePath = fileUri.fsPath;
+      const fileName = path.basename(filePath);
+
+      try {
+        const options = buildBaseOptions();
+        const sbom = await generateSbomService(filePath, options);
+
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
+        const defaultUri = workspaceFolder
+          ? vscode.Uri.joinPath(workspaceFolder, 'bom.json')
+          : vscode.Uri.file('bom.json');
+
+        const saveUri = await vscode.window.showSaveDialog({
+          defaultUri,
+          filters: { 'JSON': ['json'] },
+        });
+
+        if (!saveUri) {
+          return;
+        }
+
+        const content = Buffer.from(JSON.stringify(sbom, null, 2), 'utf-8');
+        await vscode.workspace.fs.writeFile(saveUri, content);
+
+        vscode.window.showInformationMessage(`SBOM saved to ${saveUri.fsPath}`);
+        record(context, TelemetryActions.sbomGenerationDone, { manifest: fileName, fileName: fileName });
+      } catch (error) {
+        const message = (error as Error).message;
+        vscode.window.showErrorMessage(`Failed to generate SBOM for ${fileName}: ${message}`);
+        outputChannelDep.error(`SBOM generation failed for ${filePath}: ${message}`);
+        record(context, TelemetryActions.sbomGenerationFailed, { manifest: fileName, fileName: fileName, error: message });
+      }
+    }
+  );
+
+  context.subscriptions.push(disposable);
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -571,10 +571,9 @@ function registerGenerateSbomCommand(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage(`SBOM saved to ${saveUri.fsPath}`);
         record(context, TelemetryActions.sbomGenerationDone, { manifest: fileName, fileName: fileName });
       } catch (error) {
-        const message = (error as Error).message;
-        vscode.window.showErrorMessage(`Failed to generate SBOM for ${fileName}: ${message}`);
-        outputChannelDep.error(`SBOM generation failed for ${filePath}: ${message}`);
-        record(context, TelemetryActions.sbomGenerationFailed, { manifest: fileName, fileName: fileName, error: message });
+        vscode.window.showErrorMessage(`RHDA: Failed to generate SBOM. ${buildNotificationErrorMessage(error as Error)}`);
+        outputChannelDep.error(`SBOM generation failed for ${filePath}: ${buildLogErrorMessage(error as Error)}`);
+        record(context, TelemetryActions.sbomGenerationFailed, { manifest: fileName, fileName: fileName, error: (error as Error).message });
       }
     }
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 
 import * as commands from './commands';
 import { GlobalState, EXTENSION_QUALIFIED_ID, REDHAT_MAVEN_REPOSITORY, REDHAT_MAVEN_REPOSITORY_DOCUMENTATION_URL, REDHAT_CATALOG } from './constants';
-import { generateRHDAReport } from './rhda';
+import { generateRHDAReport, getFileType } from './rhda';
 import { globalConfig } from './config';
 import { StatusMessages, PromptText } from './constants';
 import { caStatusBarProvider } from './caStatusBarProvider';
@@ -534,17 +534,27 @@ function registerGenerateSbomCommand(context: vscode.ExtensionContext) {
         return;
       }
 
+      if (fileUri.scheme !== 'file') {
+        vscode.window.showErrorMessage('SBOM generation is only supported for local files.');
+        return;
+      }
+
       const filePath = fileUri.fsPath;
       const fileName = path.basename(filePath);
+
+      const fileType = getFileType(filePath);
+      if (!fileType || fileType === 'docker') {
+        vscode.window.showErrorMessage(`File ${fileName} is not supported for SBOM generation.`);
+        return;
+      }
 
       try {
         const options = buildBaseOptions();
         const sbom = await generateSbomService(filePath, options);
 
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
-        const defaultUri = workspaceFolder
-          ? vscode.Uri.joinPath(workspaceFolder, 'bom.json')
-          : vscode.Uri.file('bom.json');
+        const owningFolder = vscode.workspace.getWorkspaceFolder(fileUri)?.uri
+          ?? vscode.Uri.file(path.dirname(filePath));
+        const defaultUri = vscode.Uri.joinPath(owningFolder, 'bom.json');
 
         const saveUri = await vscode.window.showSaveDialog({
           defaultUri,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -544,7 +544,7 @@ function registerGenerateSbomCommand(context: vscode.ExtensionContext) {
 
       const fileType = getFileType(filePath);
       if (!fileType || fileType === 'docker') {
-        vscode.window.showErrorMessage(`File ${fileName} is not supported for SBOM generation.`);
+        vscode.window.showErrorMessage(`File ${filePath} is not supported for SBOM generation.`);
         return;
       }
 

--- a/src/redhatTelemetry.ts
+++ b/src/redhatTelemetry.ts
@@ -21,7 +21,9 @@ enum TelemetryActions {
   llmAnalysisDiagnosticsHovered = 'llm_analysis_diagnostics_hovered',
   llmAnalysisReportDone = 'llm_analysis_report_done',
   batchAnalysisDone = 'batch_analysis_done',
-  batchAnalysisFailed = 'batch_analysis_failed'
+  batchAnalysisFailed = 'batch_analysis_failed',
+  sbomGenerationDone = 'sbom_generation_done',
+  sbomGenerationFailed = 'sbom_generation_failed'
 }
 
 let telemetryServiceObj: TelemetryService | null = null;

--- a/src/rhda.ts
+++ b/src/rhda.ts
@@ -178,4 +178,4 @@ function metricsFromReport(report: string): ResponseMetrics | undefined {
   };
 }
 
-export { generateRHDAReport, updateCurrentWebviewPanel };
+export { generateRHDAReport, updateCurrentWebviewPanel, getFileType };

--- a/test/exhortServices.test.ts
+++ b/test/exhortServices.test.ts
@@ -16,11 +16,14 @@ suite('ExhortServices module', async () => {
 
   const batchAnalysisReportHtmlMock = '<html>RHDA Batch Report Mock</html>';
 
+  const sbomMock = { bomFormat: 'CycloneDX', specVersion: '1.4', components: [] };
+
   const exhortMock = {
     default: {
       stackAnalysis: async () => stackAnalysisReportHtmlMock,
       stackAnalysisBatch: async () => batchAnalysisReportHtmlMock,
       validateToken: async (statusCode: any) => ({ status: statusCode }),
+      generateSbom: async () => sbomMock,
     }
   };
 
@@ -105,6 +108,35 @@ suite('ExhortServices module', async () => {
       })
       .catch((error: Error) => {
         expect(error.message).to.equal('Batch Analysis Error');
+      });
+  });
+
+  test('should generate SBOM from Exhort generateSbom service', async () => {
+    await exhortServicesRewire.generateSbomService('mock/path/to/manifest', {})
+      .then((result: object) => {
+        expect(result).to.deep.equal(sbomMock);
+      });
+  });
+
+  test('should fail to generate SBOM and reject with error', async () => {
+
+    // eslint-disable-next-line @typescript-eslint/no-shadow
+    const exhortMock = {
+      default: {
+        generateSbom: async () => {
+          throw new Error('SBOM Generation Error');
+        },
+      }
+    };
+
+    exhortServicesRewire.__Rewire__('trustify_da_javascript_client_1', exhortMock);
+
+    await exhortServicesRewire.generateSbomService('mock/path/to/manifest', {})
+      .then(() => {
+        throw new Error('should have thrown SBOM Generation Error');
+      })
+      .catch((error: Error) => {
+        expect(error.message).to.equal('SBOM Generation Error');
       });
   });
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -29,7 +29,8 @@ suite('Extension module', () => {
       commands.STACK_ANALYSIS_FROM_EDITOR_COMMAND,
       commands.STACK_ANALYSIS_FROM_EXPLORER_COMMAND,
       commands.STACK_ANALYSIS_FROM_PIE_BTN_COMMAND,
-      commands.STACK_ANALYSIS_FROM_STATUS_BAR_COMMAND
+      commands.STACK_ANALYSIS_FROM_STATUS_BAR_COMMAND,
+      commands.GENERATE_SBOM_COMMAND
     ];
     expect((await vscode.commands.getCommands(true))).to.include.members(FABRIC8_COMMANDS);
   });


### PR DESCRIPTION
## Summary
- Add "RHDA: Generate SBOM" command that generates a CycloneDX SBOM from a supported manifest file and saves it to a user-chosen location via native Save File dialog
- Command available from Command Palette, editor title, explorer context, and editor context menus for all supported manifest files
- Includes telemetry tracking (`sbom_generation_done` / `sbom_generation_failed`), unit tests, and README documentation

## Test plan
- [ ] Verify "RHDA: Generate SBOM" appears in Command Palette
- [ ] Verify command appears in context menus for supported manifest files (pom.xml, package.json, go.mod, requirements.txt, pyproject.toml, build.gradle, Cargo.toml)
- [ ] Verify Save File dialog opens with default filename `bom.json`
- [ ] Verify SBOM is generated and saved in CycloneDX JSON format
- [ ] Verify success message is shown after saving
- [ ] Verify error message is shown on failure
- [ ] Verify telemetry events are recorded
- [ ] Run unit tests: `npm test`

Resolves: TC-3995

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a VS Code command to generate a CycloneDX SBOM from supported manifest files and integrate it with existing analysis services, telemetry, and UI surfaces.

New Features:
- Introduce the `rhda.generateSbom` command to generate a CycloneDX SBOM from supported manifest files and save it via a Save File dialog.

Enhancements:
- Add `generateSbomService` wrapper around the Exhort client and extend `batchStackAnalysisService` to use shared options while handling batch metadata explicitly.
- Wire SBOM generation into the extension activation flow and record success/failure via new telemetry actions.
- Expose the Generate SBOM command in explorer, editor, and command palette menus for supported manifest file types.
- Update the Trustify DA JavaScript client dependency to a newer pre-release version.

Build:
- Update the `@trustify-da/trustify-da-javascript-client` dependency version in package.json.

Documentation:
- Document the new Generate SBOM command usage and entry points in the README.

Tests:
- Add unit tests for the new SBOM generation service, including error handling, and extend extension activation tests to cover command registration.