### PR TITLE
chore: bump javascript-api version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
         "@trustify-da/trustify-da-api-model": "^2.0.7",
-        "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.2e5fe72",
+        "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.76e1fef",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "cli-table3": "^0.6.5",
@@ -1025,9 +1025,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@trustify-da/trustify-da-javascript-client": {
-      "version": "0.3.0-ea.2e5fe72",
-      "resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-javascript-client/-/trustify-da-javascript-client-0.3.0-ea.2e5fe72.tgz",
-      "integrity": "sha512-AzAydfEGjAClvIA3SUTl5KphvtqBLncJTd6V+ydgwvhmYdxIkfeTqmiyvD1aZBwZqwDkeMRNtdvUvG5/kqfFDA==",
+      "version": "0.3.0-ea.76e1fef",
+      "resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-javascript-client/-/trustify-da-javascript-client-0.3.0-ea.76e1fef.tgz",
+      "integrity": "sha512-yL2qTZgRdcUD7kG03MuJ/0dgohA6VO83tZbqmreKBuIzPhpdVOdr+amhaAHe3Nse7iaTZyY+P8QI4SZQWLlM4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -546,7 +546,7 @@
   "dependencies": {
     "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
     "@trustify-da/trustify-da-api-model": "^2.0.7",
-    "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.2e5fe72",
+    "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.76e1fef",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "^1.0.11",
     "cli-table3": "^0.6.5",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update npm dependency version for @trustify-da/trustify-da-javascript-client.