### PR TITLE
fix: filter multi-stage Dockerfile build aliases from image analysis

### DIFF
--- a/src/imageAnalysis.ts
+++ b/src/imageAnalysis.ts
@@ -43,6 +43,7 @@ interface IImageRef {
  */
 class DockerImageAnalysis {
   args: Map<string, string> = new Map<string, string>();
+  aliases: Set<string> = new Set<string>();
   images: IImageRef[] = [];
   imageAnalysisReportHtml: string = '';
   filePath: string;
@@ -123,10 +124,16 @@ class DockerImageAnalysis {
       let imageData = imageMatch[1];
       imageData = this.replaceArgsInString(imageData);
       imageData = imageData.replace(this.PLATFORM_REGEX, '');
+
+      const asMatch = imageData.match(this.AS_REGEX);
+      if (asMatch) {
+        this.aliases.add(asMatch[0].trim().split(/\s+/)[1].toLowerCase());
+      }
+
       imageData = imageData.replace(this.AS_REGEX, '');
       imageData = imageData.trim();
 
-      if (imageData === 'scratch') {
+      if (imageData === 'scratch' || this.aliases.has(imageData.toLowerCase())) {
         return;
       }
 

--- a/src/providers/docker.ts
+++ b/src/providers/docker.ts
@@ -12,6 +12,7 @@ import { IImageProvider, IImage, Image } from '../imageAnalysis/collector';
 export class ImageProvider implements IImageProvider {
 
   args: Map<string, string> = new Map<string, string>();
+  aliases: Set<string> = new Set<string>();
 
   /**
    * Regular expression for matching 'FROM' statements.
@@ -76,10 +77,16 @@ export class ImageProvider implements IImageProvider {
       let imageData = imageMatch[1];
       imageData = this.replaceArgsInString(imageData);
       imageData = imageData.replace(this.PLATFORM_REGEX, '');
+
+      const asMatch = imageData.match(this.AS_REGEX);
+      if (asMatch) {
+        this.aliases.add(asMatch[0].trim().split(/\s+/)[1].toLowerCase());
+      }
+
       imageData = imageData.replace(this.AS_REGEX, '');
       imageData = imageData.trim();
 
-      if (imageData === 'scratch') {
+      if (imageData === 'scratch' || this.aliases.has(imageData.toLowerCase())) {
         return;
       }
 

--- a/test/imageAnalysis.test.ts
+++ b/test/imageAnalysis.test.ts
@@ -25,6 +25,7 @@ ARG ARG_TAG=latest
 FROM --platform=linux/amd64 \${ARG_IMAGE}:\${ARG_TAG} as stage1$ARG_FAKE
 FROM ubuntu
 FROM scratch
+FROM stage1 AS runner
     `;
     const encodedMockFileContent = Buffer.from(mockFileContent, 'utf-8');
 

--- a/test/providers/docker.test.ts
+++ b/test/providers/docker.test.ts
@@ -249,6 +249,60 @@ FROM alpine
         ]);
     });
 
+    test('tests multi-stage build aliases are filtered', async () => {
+        const deps = dependencyProvider.collect(`
+FROM node:26-alpine AS base
+RUN npm install
+FROM base AS builder
+RUN npm run build
+FROM base AS runner
+COPY --from=builder /app /app
+        `);
+        expect(deps.length).to.equal(1);
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'node:26-alpine', position: { line: 2, column: 0 } },
+                line: 'FROM node:26-alpine AS base'
+            }
+        ]);
+    });
+
+    test('tests multi-stage build aliases are case-insensitive', async () => {
+        const deps = dependencyProvider.collect(`
+FROM alpine:latest AS Base
+FROM base AS builder
+FROM BASE AS runner
+        `);
+        expect(deps.length).to.equal(1);
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'alpine:latest', position: { line: 2, column: 0 } },
+                line: 'FROM alpine:latest AS Base'
+            }
+        ]);
+    });
+
+    test('tests multi-stage build with platform and aliases', async () => {
+        const deps = dependencyProvider.collect(`
+FROM --platform=linux/amd64 node:20 AS build
+FROM build AS test
+FROM --platform=linux/arm64 alpine:3.19 AS runtime
+        `);
+        expect(deps.length).to.equal(2);
+        expect(deps).is.eql([
+            {
+                name: { value: 'node:20', position: { line: 2, column: 0 } },
+                line: 'FROM --platform=linux/amd64 node:20 AS build',
+                platform: 'linux/amd64'
+            },
+            {
+                name: { value: 'alpine:3.19', position: { line: 4, column: 0 } },
+                line: 'FROM --platform=linux/arm64 alpine:3.19 AS runtime',
+                platform: 'linux/arm64'
+            }
+        ]);
+    });
+
     test('tests file with various Dockerfile/Containerfile components', async () => {
         const deps = dependencyProvider.collect(`
 # Use an official Node.js runtime as a parent image


### PR DESCRIPTION
## Summary

- Track `AS` alias names from Dockerfile `FROM` lines and skip subsequent `FROM` lines that reference a build stage alias instead of a real image
- Fixes both the diagnostics code path (`ImageProvider` in `src/providers/docker.ts`) and the report generation code path (`DockerImageAnalysis` in `src/imageAnalysis.ts`)
- Adds 3 new test cases covering alias filtering, case-insensitive matching, and platform+alias combinations

Closes #893

## Context

In multi-stage Dockerfiles like:
```dockerfile
FROM node:26-alpine AS base
FROM base AS builder
FROM base AS runner
```

The extension was treating `base` as a real image name and passing it to `skopeo inspect`, which failed with:
```
Error parsing image name "docker://base:latest": reading manifest latest in docker.io/library/base: requested access to the resource is denied
```

The IntelliJ plugin already handles this correctly by maintaining a set of aliases. This PR brings the VS Code extension to parity.

## Test plan

- [x] Existing multi-stage build tests still pass (AS stripping)
- [x] New test: aliases from `FROM image AS alias` are filtered from subsequent `FROM alias` lines
- [x] New test: alias matching is case-insensitive (Docker aliases are case-insensitive)
- [x] New test: platform flags combined with aliases work correctly
- [x] `imageAnalysis.test.ts` updated to include alias reference in mock Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Filter multi-stage Dockerfile build stage aliases from image analysis to avoid treating aliases as real images.

Bug Fixes:
- Ignore FROM lines that reference previously defined build stage aliases instead of real images in both diagnostics and report generation paths.

Tests:
- Add tests covering alias filtering in multi-stage builds, case-insensitive alias handling, and platform flags combined with aliases in Dockerfiles.