### PR TITLE
docs: update CHANGELOG with PRs since v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,24 @@
 
 ### Enhancements
 
-- Added license compatibility checking feature that detects license mismatches between manifest files and LICENSE files, and identifies dependencies with incompatible licenses. See configuration option `redHatDependencyAnalytics.licenseCheckEnabled` for details.
+- Added "Generate SBOM" command that creates a CycloneDX SBOM from supported manifest files and saves it to a user-chosen location. See [PR#889](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/889) for details.
+- Added support for `pyproject.toml` files with both PEP 621 and Poetry dependency formats, including new `uv` and `poetry` executable path settings. See [PR#885](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/885) for details.
+- Added batch workspace analysis command for analyzing all manifest files in a workspace. See [PR#880](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/880) for details.
+- Added support for Rust `Cargo.toml` manifest files. See [PR#878](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/878) for details.
+- Added license compatibility checking feature that detects license mismatches between manifest files and LICENSE files, and identifies dependencies with incompatible licenses. See [PR#874](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/874) for details.
+- Added Red Hat OIDC authentication support. See [PR#844](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/844) for details.
+
+### Fixes
+
+- Fixed multi-stage Dockerfile build aliases being treated as real image names and causing inspection failures. See [PR#897](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/897) for details.
+- Fixed proxy settings from `http.proxy` being ignored during the first auto-analysis at VS Code startup. See [PR#884](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/884) for details.
+- Fixed component analysis being triggered for files opened in the background rather than only for visible editors. See [PR#868](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/868) for details.
+- Fixed OIDC token not being passed to the JavaScript API. See [PR#867](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/867) for details.
+
+### Chores
+
+- Bumped JavaScript API for improved `requirements.txt` handling. See [PR#892](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/892), [PR#875](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/875) for details.
+- Changed default for Go MVS algorithm to enabled. See [PR#862](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/862) for details.
 
 ## 0.10.2 (December 19th 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Enhancements
 
-- Added "Generate SBOM" command that creates a CycloneDX SBOM from supported manifest files and saves it to a user-chosen location. See [PR#889](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/889) for details.
-- Added support for `pyproject.toml` files with both PEP 621 and Poetry dependency formats, including new `uv` and `poetry` executable path settings. See [PR#885](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/885) for details.
+- Added "Generate SBOM" command that creates a CycloneDX SBOM from supported manifest files and saves it to a user-defined location. See [PR#889](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/889) for details.
+- Added trusted library recommendations with per-provider remediation instructions. See [PR#891](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/891) for details.
+- Added support for `pyproject.toml` files with both PEP 621 and Poetry dependency formats, including the new `uv` and `poetry` executable path settings. See [PR#885](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/885) for details.
 - Added batch workspace analysis command for analyzing all manifest files in a workspace. See [PR#880](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/880) for details.
 - Added support for Rust `Cargo.toml` manifest files. See [PR#878](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/878) for details.
-- Added license compatibility checking feature that detects license mismatches between manifest files and LICENSE files, and identifies dependencies with incompatible licenses. See [PR#874](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/874) for details.
+- Added a license compatibility checking feature that detects license mismatches between manifest files and `LICENSE` files, and identifies dependencies with incompatible licenses. Enable via `redHatDependencyAnalytics.licenseCheckEnabled`. See [PR#874](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/874) for details.
+- Added support for `build.gradle.kts` (Gradle Kotlin DSL) manifest files. See [PR#903](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/903) for details.
 - Added Red Hat OIDC authentication support. See [PR#844](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/844) for details.
 
 ### Fixes
@@ -20,8 +22,11 @@
 
 ### Chores
 
-- Bumped JavaScript API for improved `requirements.txt` handling. See [PR#892](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/892), [PR#875](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/875) for details.
-- Changed default for Go MVS algorithm to enabled. See [PR#862](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/862) for details.
+- Changed the default for Go MVS algorithm to enabled. See [PR#862](https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/862) for details.
+
+### Known Issues
+
+- In rare cases, opening the stack analysis HTML report might fail with an error. This can be caused by an upstream VS Code bug ([vscode#125993](https://github.com/microsoft/vscode/issues/125993)). To workaround this issue, restart all VS Code instances, or remove the VS Code webview cache directory.
 
 ## 0.10.2 (December 19th 2025)
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Specify glob patterns for manifests to be ignored for background analysis e.g. `
 
 	![ Animated screenshot showing how to access the _Quick Fix..._ menu, and switching to a Red Hat recommended package version ](images/screencasts/quickfix.gif)
 
-	<br >**IMPORTANT:** For Maven projects only, when analyzing a `pom.xml` file.
+	<br >**IMPORTANT:** For Maven and Gradle projects, when analyzing a `pom.xml` or `build.gradle`/`build.gradle.kts` file.
 	You must configure Red Hat's generally available (GA) repository to use the recommendations or remediation.
 	Add this repository, `https://maven.repository.redhat.com/ga/`, to your project's configuration.
 
@@ -199,7 +199,7 @@ Specify glob patterns for manifests to be ignored for background analysis e.g. `
 - **License compatibility checking**
 	<br >Red Hat Dependency Analytics automatically checks for license compatibility issues in your project:
 
-	- **License mismatch detection**: For projects with license fields in their manifest files (`package.json`, `pom.xml`, `build.gradle`, `Cargo.toml`), the extension detects mismatches between the license declared in the manifest and the LICENSE file. A red underline appears on the license field with a quick fix to update the manifest with the LICENSE file's value.
+	- **License mismatch detection**: For projects with license fields in their manifest files (`package.json`, `pom.xml`, `build.gradle`, `Cargo.toml`, `pyproject.toml`), the extension detects mismatches between the license declared in the manifest and the LICENSE file. A red underline appears on the license field with a quick fix to update the manifest with the LICENSE file's value.
 
 	- **Incompatible dependency licenses**: The extension identifies dependencies whose licenses are more restrictive than your project's license. A notification displays the count of incompatible dependencies, helping you maintain license compliance.
 


### PR DESCRIPTION
## Summary
- Update the Unreleased section of CHANGELOG.md with all relevant PRs merged since the v0.10.2 release
- Covers 6 enhancements, 4 fixes, and 2 chore entries

## Test plan
- [x] Verify all PR numbers link to valid PRs
- [x] Verify descriptions match the actual PR content
- [x] No code changes, documentation only

## Summary by Sourcery

Update the Unreleased section of the changelog to document recent enhancements, bug fixes, and chore changes since v0.10.2.

New Features:
- Document new SBOM generation command for supported manifests.
- Document support for pyproject.toml with PEP 621 and Poetry formats, including new uv and poetry settings.
- Document batch workspace analysis for all manifest files in a workspace.
- Document support for Rust Cargo.toml manifests.
- Document availability of license compatibility checking for manifests and dependencies.
- Document addition of Red Hat OIDC authentication support.

Bug Fixes:
- Document fix for multi-stage Dockerfile build aliases being misidentified as image names.
- Document fix for http.proxy settings not applying to first auto-analysis at startup.
- Document fix to restrict component analysis to visible editors instead of background files.
- Document fix for OIDC token not being passed to the JavaScript API.

Documentation:
- Refresh changelog Unreleased section with categorized entries and links to all relevant pull requests since v0.10.2.

Chores:
- Document JavaScript API version bump for improved requirements.txt handling.
- Document change to default-enable the Go MVS algorithm.