### PR TITLE
feat(gradle): add build.gradle.kts (Gradle Kotlin DSL) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "workspaceContains:**/requirements.txt",
     "workspaceContains:**/pyproject.toml",
     "workspaceContains:**/build.gradle",
+    "workspaceContains:**/build.gradle.kts",
     "workspaceContains:**/Cargo.toml",
     "workspaceContains:**/Dockerfile",
     "workspaceContains:**/Containerfile",
@@ -125,6 +126,11 @@
         },
         {
           "command": "rhda.stackAnalysisFromPieBtn",
+          "when": "resourceFilename == build.gradle.kts",
+          "group": "navigation"
+        },
+        {
+          "command": "rhda.stackAnalysisFromPieBtn",
           "when": "resourceFilename == Cargo.toml",
           "group": "navigation"
         },
@@ -135,7 +141,7 @@
         },
         {
           "command": "rhda.generateSbom",
-          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == Cargo.toml"
+          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == build.gradle.kts || resourceFilename == Cargo.toml"
         }
       ],
       "explorer/context": [
@@ -165,6 +171,10 @@
         },
         {
           "command": "rhda.stackAnalysisFromExplorer",
+          "when": "resourceFilename == build.gradle.kts"
+        },
+        {
+          "command": "rhda.stackAnalysisFromExplorer",
           "when": "resourceFilename == Cargo.toml"
         },
         {
@@ -173,7 +183,7 @@
         },
         {
           "command": "rhda.generateSbom",
-          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == Cargo.toml"
+          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == build.gradle.kts || resourceFilename == Cargo.toml"
         }
       ],
       "editor/context": [
@@ -203,6 +213,10 @@
         },
         {
           "command": "rhda.stackAnalysisFromEditor",
+          "when": "resourceFilename == build.gradle.kts"
+        },
+        {
+          "command": "rhda.stackAnalysisFromEditor",
           "when": "resourceFilename == Cargo.toml"
         },
         {
@@ -211,7 +225,7 @@
         },
         {
           "command": "rhda.generateSbom",
-          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == Cargo.toml"
+          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == build.gradle.kts || resourceFilename == Cargo.toml"
         }
       ],
       "commandPalette": [
@@ -229,7 +243,7 @@
         },
         {
           "command": "rhda.generateSbom",
-          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == Cargo.toml"
+          "when": "resourceFilename == pom.xml || resourceFilename == package.json || resourceFilename == go.mod || resourceFilename == requirements.txt || resourceFilename == pyproject.toml || resourceFilename == build.gradle || resourceFilename == build.gradle.kts || resourceFilename == Cargo.toml"
         }
       ]
     },

--- a/src/fileHandler.ts
+++ b/src/fileHandler.ts
@@ -48,7 +48,7 @@ export class AnalysisMatcher {
       providerName: 'pyproject'
     },
     {
-      pattern: /^build\.gradle$/,
+      pattern: /^build\.gradle(\.kts)?$/,
       callback: (tokenProvider, path, contents) => { return dependencyDiagnostics.performDiagnostics(tokenProvider, path, contents, new BuildGradle()); },
       providerName: 'gradle'
     },

--- a/src/providers/build.gradle.ts
+++ b/src/providers/build.gradle.ts
@@ -30,9 +30,19 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
   FIND_KEY_VALUE_PAIRS_WITH_EQUALS_REGEX: RegExp = /\b(\w+)\s*=\s*(['"])(.*?)\2/;
 
   /**
+   * Regular expression for locating key-value pairs with equals signs (global, for dependency extraction).
+   */
+  FIND_KEY_VALUE_PAIRS_WITH_EQUALS_GLOBAL_REGEX: RegExp = /\b(\w+)\s*=\s*(['"])(.*?)\2/g;
+
+  /**
    * Regular expression for matching key value pairs.
    */
   SPLIT_KEY_VALUE_PAIRS_WITH_COLON_REGEX: RegExp = /\s*:\s*/;
+
+  /**
+   * Regular expression for splitting key-value pairs with equals signs.
+   */
+  SPLIT_KEY_VALUE_PAIRS_WITH_EQUALS_REGEX: RegExp = /\s*=\s*/;
 
   /**
    * Regular expression for matching strings enclosed in double or single quotes.
@@ -101,16 +111,22 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
     const myClassObj = { group: '', name: '', version: '' };
     let depData: string;
 
-    const keyValuePairs = cleanLine.match(this.FIND_KEY_VALUE_PAIRS_WITH_COLON_REGEX);
+    // Try colon-separated map notation first (Groovy: group: "log4j", name: "log4j")
+    // then equals-separated map notation (Kotlin DSL: group = "log4j", name = "log4j")
+    const colonKeyValuePairs = cleanLine.match(this.FIND_KEY_VALUE_PAIRS_WITH_COLON_REGEX);
+    const equalsKeyValuePairs = !colonKeyValuePairs ? cleanLine.match(this.FIND_KEY_VALUE_PAIRS_WITH_EQUALS_GLOBAL_REGEX) : null;
+    const keyValuePairs = colonKeyValuePairs || equalsKeyValuePairs;
+    const splitRegex = colonKeyValuePairs ? this.SPLIT_KEY_VALUE_PAIRS_WITH_COLON_REGEX : this.SPLIT_KEY_VALUE_PAIRS_WITH_EQUALS_REGEX;
+
     if (keyValuePairs) {
       // extract data from dependency in Map format
       keyValuePairs.forEach(pair => {
-        const [key, value] = pair.split(this.SPLIT_KEY_VALUE_PAIRS_WITH_COLON_REGEX);
+        const [key, value] = pair.split(splitRegex);
         const match = value.match(this.BETWEEN_QUOTES_REGEX);
         if (!match) { return; }
 
         const valueData = match[2];
-        switch (key) {
+        switch (key.trim()) {
           case 'group':
             myClassObj.group = valueData;
             break;
@@ -147,9 +163,10 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
     // For Gradle, we place diagnostics on the dependency string in the file
     let namePosition = { line: index + 1, column: 0 };
     if (keyValuePairs) {
-      // For map format like: group: "log4j", name: "log4j"
+      // For map format like: group: "log4j" (Groovy) or group = "log4j" (Kotlin DSL)
       // Find the start of the group value
-      const groupMatch = line.match(/group\s*:\s*(['"])(.*?)\1/);
+      const groupPattern = colonKeyValuePairs ? /group\s*:\s*(['"])(.*?)\1/ : /group\s*=\s*(['"])(.*?)\1/;
+      const groupMatch = line.match(groupPattern);
       if (groupMatch) {
         const groupStr = groupMatch[0];
         const groupValue = groupMatch[2];
@@ -177,10 +194,12 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
       // if version is not specified, generate placeholder template
       if (keyValuePairs) {
         const quotedName = `"${myClassObj.name}"`;
+        const sep = colonKeyValuePairs ? ':' : '=';
+        const nameFragment = `name${sep === ':' ? ': ' : ' = '}${quotedName}`;
         dep.context = {
-          value: `name: ${quotedName}, version: "${VERSION_PLACEHOLDER}"`, range: new Range(
-            new Position(index + 1, line.indexOf(`name: ${quotedName}`) + 1),
-            new Position(index + 1, line.indexOf(`name: ${quotedName}`) + `name: ${quotedName}`.length + 1),
+          value: `${nameFragment}, version${sep === ':' ? ': ' : ' = '}"${VERSION_PLACEHOLDER}"`, range: new Range(
+            new Position(index + 1, line.indexOf(nameFragment) + 1),
+            new Position(index + 1, line.indexOf(nameFragment) + nameFragment.length + 1),
           )
         };
       } else {

--- a/src/rhda.ts
+++ b/src/rhda.ts
@@ -29,6 +29,7 @@ const PACKAGE_JSON = 'package.json';
 const REQUIREMENTS_TXT = 'requirements.txt';
 const PYPROJECT_TOML = 'pyproject.toml';
 const BUILD_GRADLE = 'build.gradle';
+const BUILD_GRADLE_KTS = 'build.gradle.kts';
 const CARGO_TOML = 'Cargo.toml';
 const DOCKERFILE = 'Dockerfile';
 const CONTAINERFILE = 'Containerfile';
@@ -52,7 +53,7 @@ function getFileType(filePath: string): supportedFileTypes | undefined {
   else if (basename === REQUIREMENTS_TXT || basename === PYPROJECT_TOML) {
     return 'python';
   }
-  else if (basename === BUILD_GRADLE) {
+  else if (basename === BUILD_GRADLE || basename === BUILD_GRADLE_KTS) {
     return 'gradle';
   }
   else if (basename === CARGO_TOML) {

--- a/test/providers/build.gradle.test.ts
+++ b/test/providers/build.gradle.test.ts
@@ -318,6 +318,34 @@ dependencies {
         ]);
     });
 
+    /// Verifies that Kotlin DSL string notation dependencies are correctly parsed.
+    test('tests build.gradle.kts with Kotlin DSL string notation dependencies', async () => {
+        const deps = dependencyProvider.collect(`
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("log4j:log4j:1.2.3")
+    implementation("org.apache.commons:commons-lang3:3.12.0")
+}
+        `);
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'log4j/log4j', position: { line: 11, column: 21 } },
+                version: { value: '1.2.3', position: { line: 11, column: 33 } }
+            },
+            {
+                name: { value: 'org.apache.commons/commons-lang3', position: { line: 12, column: 21 } },
+                version: { value: '3.12.0', position: { line: 12, column: 54 } }
+            }
+        ]);
+    });
+
     test('tests build.gradle dependencies with missing version parameter', async () => {
         const deps = dependencyProvider.collect(`
 plugins {

--- a/test/providers/build.gradle.test.ts
+++ b/test/providers/build.gradle.test.ts
@@ -346,6 +346,108 @@ dependencies {
         ]);
     });
 
+    /// Verifies that Kotlin DSL string notation dependencies without a version are correctly parsed.
+    test('tests build.gradle.kts with Kotlin DSL string notation without version', async () => {
+        const deps = dependencyProvider.collect(`
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("log4j:log4j")
+}
+        `);
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'log4j/log4j', position: { line: 11, column: 21 } },
+                context: { value: 'log4j:log4j:__VERSION__', range: { start: { line: 11, character: 21 }, end: { line: 11, character: 32 } } }
+            }
+        ]);
+    });
+
+    /// Verifies that Kotlin DSL string notation dependencies with trailing comments are correctly parsed.
+    test('tests build.gradle.kts with Kotlin DSL trailing comments', async () => {
+        const deps = dependencyProvider.collect(`
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("log4j:log4j:1.2.3") // some comment
+    implementation("org.apache.commons:commons-lang3:3.12.0") // another comment
+}
+        `);
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'log4j/log4j', position: { line: 11, column: 21 } },
+                version: { value: '1.2.3', position: { line: 11, column: 33 } }
+            },
+            {
+                name: { value: 'org.apache.commons/commons-lang3', position: { line: 12, column: 21 } },
+                version: { value: '3.12.0', position: { line: 12, column: 54 } }
+            }
+        ]);
+    });
+
+    /// Verifies that Kotlin DSL map notation dependencies (using = instead of :) are correctly parsed.
+    test('tests build.gradle.kts with Kotlin DSL map notation dependencies', async () => {
+        const deps = dependencyProvider.collect(`
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(group = "log4j", name = "log4j", version = "1.2.3")
+    implementation(version = "3.12.0", name = "commons-lang3", group = "org.apache.commons")
+}
+        `);
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'log4j/log4j', position: { line: 11, column: 29 } },
+                version: { value: '1.2.3', position: { line: 11, column: 64 } }
+            },
+            {
+                name: { value: 'org.apache.commons/commons-lang3', position: { line: 12, column: 73 } },
+                version: { value: '3.12.0', position: { line: 12, column: 31 } }
+            }
+        ]);
+    });
+
+    /// Verifies that Kotlin DSL map notation without a version is correctly parsed.
+    test('tests build.gradle.kts with Kotlin DSL map notation without version', async () => {
+        const deps = dependencyProvider.collect(`
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(group = "log4j", name = "log4j")
+}
+        `);
+        expect(deps).is.containSubset([
+            {
+                name: { value: 'log4j/log4j', position: { line: 11, column: 29 } },
+                context: { value: 'name = "log4j", version = "__VERSION__"', range: { start: { line: 11, character: 37 }, end: { line: 11, character: 51 } } }
+            }
+        ]);
+    });
+
     test('tests build.gradle dependencies with missing version parameter', async () => {
         const deps = dependencyProvider.collect(`
 plugins {


### PR DESCRIPTION
## Summary
- Register `build.gradle.kts` in activation events, context menus (editor/title, explorer, editor), and SBOM generation commands in `package.json`
- Update `AnalysisMatcher` regex to match both `build.gradle` and `build.gradle.kts`, reusing the existing `BuildGradle` provider
- Add `BUILD_GRADLE_KTS` constant and update `getFileType()` to recognize the `.kts` variant as `gradle` type
- Add test for Kotlin DSL string notation dependency parsing

Implements [TC-4659](https://redhat.atlassian.net/browse/TC-4659)

## Test plan
- [x] New test for Kotlin DSL string notation dependencies passes
- [x] All existing `build.gradle` tests continue to pass (no regression)
- [x] Manual testing: extension activates on workspace with `build.gradle.kts`
- [x] Manual testing: context menus and pie button appear for `build.gradle.kts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4659]: https://redhat.atlassian.net/browse/TC-4659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add Gradle Kotlin DSL (build.gradle.kts) support across the extension and ensure dependencies are correctly parsed.

New Features:
- Enable extension activation and stack analysis commands for projects using build.gradle.kts files.
- Allow SBOM generation commands to run against build.gradle.kts files alongside existing build.gradle support.

Enhancements:
- Treat build.gradle.kts files as Gradle type in file type detection and reuse the existing Gradle dependency provider for them.

Tests:
- Add a test verifying dependency parsing from Kotlin DSL string-notation dependencies in build.gradle.kts files.