### PR TITLE
fix: narrow stackAnalysisBatch return type to fix TS compilation

### DIFF
--- a/src/exhortServices.ts
+++ b/src/exhortServices.ts
@@ -119,10 +119,13 @@ async function tokenValidationService(options: Options, source: string): Promise
  */
 async function batchStackAnalysisService(workspaceRoot: string, options: Options): Promise<string> {
   const result = await exhort.stackAnalysisBatch(workspaceRoot, true, options);
-  if (result && typeof result === 'object' && 'analysis' in result) {
-    return result.analysis as string;
+  if (typeof result === 'string') {
+    return result;
   }
-  return result as string;
+  if (result && typeof result === 'object' && 'analysis' in result && typeof result.analysis === 'string') {
+    return result.analysis;
+  }
+  throw new Error('Unexpected batch stack analysis result shape');
 }
 
 /**

--- a/src/exhortServices.ts
+++ b/src/exhortServices.ts
@@ -118,11 +118,11 @@ async function tokenValidationService(options: Options, source: string): Promise
  * @returns A promise resolving to the batch stack analysis report in HTML format.
  */
 async function batchStackAnalysisService(workspaceRoot: string, options: Options): Promise<string> {
-  if (options.batchMetadata) {
-    const { analysis } = await exhort.stackAnalysisBatch(workspaceRoot, true, { ...options, batchMetadata: true });
-    return analysis;
+  const result = await exhort.stackAnalysisBatch(workspaceRoot, true, options);
+  if (result && typeof result === 'object' && 'analysis' in result) {
+    return result.analysis as string;
   }
-  return await exhort.stackAnalysisBatch(workspaceRoot, true, { ...options, batchMetadata: false });
+  return result as string;
 }
 
 /**

--- a/test/exhortServices.test.ts
+++ b/test/exhortServices.test.ts
@@ -89,6 +89,48 @@ suite('ExhortServices module', async () => {
       });
   });
 
+  test('should extract analysis from batch result object with metadata', async () => {
+    const batchResultWithMetadata = {
+      analysis: '<html>Batch Report With Metadata</html>',
+      metadata: { totalManifests: 3 }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-shadow
+    const exhortMock = {
+      default: {
+        stackAnalysisBatch: async () => batchResultWithMetadata,
+      }
+    };
+
+    exhortServicesRewire.__Rewire__('trustify_da_javascript_client_1', exhortMock);
+
+    await exhortServicesRewire.batchStackAnalysisService('mock/workspace/root', {})
+      .then((result: string) => {
+        expect(result).to.equal('<html>Batch Report With Metadata</html>');
+      });
+  });
+
+  test('should throw on unexpected batch analysis result shape', async () => {
+    const unexpectedResult = { someField: 'not analysis' };
+
+    // eslint-disable-next-line @typescript-eslint/no-shadow
+    const exhortMock = {
+      default: {
+        stackAnalysisBatch: async () => unexpectedResult,
+      }
+    };
+
+    exhortServicesRewire.__Rewire__('trustify_da_javascript_client_1', exhortMock);
+
+    await exhortServicesRewire.batchStackAnalysisService('mock/workspace/root', {})
+      .then(() => {
+        throw new Error('should have thrown');
+      })
+      .catch((error: Error) => {
+        expect(error.message).to.equal('Unexpected batch stack analysis result shape');
+      });
+  });
+
   test('should fail to generate RHDA batch report and reject with error', async () => {
 
     // eslint-disable-next-line @typescript-eslint/no-shadow


### PR DESCRIPTION
## Summary
- The JS client bump in #892 changed the return type of `stackAnalysisBatch` to a union type (`string | object | {analysis, metadata}`), breaking TypeScript compilation
- Replaced direct destructuring with runtime type narrowing to handle all return type variants

## Test plan
- [ ] Verify `npx tsc -p ./` compiles without errors in `exhortServices.ts`
- [ ] Verify `npx webpack --mode development` builds successfully
- [ ] Verify batch stack analysis still works correctly with and without `batchMetadata`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust batch stack analysis service to handle union return types from the JS client and restore TypeScript compatibility.

Bug Fixes:
- Fix TypeScript compilation errors caused by the updated union return type of stackAnalysisBatch in the JS client.

Enhancements:
- Simplify batch stack analysis handling by using a single call that narrows the union result at runtime.