### PR TITLE
fix(diagnostics): use issues count instead of severity to select recommendation code action

### DIFF
--- a/src/dependencyAnalysis/diagnostics.ts
+++ b/src/dependencyAnalysis/diagnostics.ts
@@ -65,8 +65,7 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<DependencyData> {
         const loc = vulnerabilityDiagnostic.range.start.line + '|' + vulnerabilityDiagnostic.range.start.character;
 
         dependencyData.forEach(dd => {
-          // TODO: we never use DiagnosticSeverity.Hint aka 3, so this always selects dd.remediationRef
-          const actionRef = vulnerabilityDiagnostic.severity < 3 ? dd.remediationRef : dd.recommendationRef;
+          const actionRef = dd.issues.length > 0 ? dd.remediationRef : dd.recommendationRef;
           if (actionRef) {
             this.createCodeAction(dependency, loc, actionRef, dependency.context, dd.sourceId, vulnerabilityDiagnostic);
           }
@@ -329,4 +328,4 @@ function processIncompatibleDependencies(
   });
 }
 
-export { performDiagnostics };
+export { DiagnosticsPipeline, performDiagnostics };

--- a/test/dependencyAnalysis/diagnostics.test.ts
+++ b/test/dependencyAnalysis/diagnostics.test.ts
@@ -1,0 +1,152 @@
+'use strict';
+
+import * as chai from 'chai';
+
+const expect = chai.expect;
+
+import { Dependency, DependencyMap } from '../../src/dependencyAnalysis/collector';
+import { DependencyData } from '../../src/dependencyAnalysis/analysis';
+import { DiagnosticsPipeline } from '../../src/dependencyAnalysis/diagnostics';
+import { getCodeActionsMap, clearCodeActionsMap } from '../../src/codeActionHandler';
+import { globalConfig } from '../../src/config';
+import { Uri } from 'vscode';
+
+suite('DiagnosticsPipeline.runDiagnostics tests', () => {
+
+    const mockUri = Uri.file('mock/path/pom.xml');
+
+    function createDependency(name: string, version: string): Dependency {
+        const dep = new Dependency({
+            value: name,
+            position: { line: 1, column: 1 }
+        });
+        dep.version = {
+            value: version,
+            position: { line: 1, column: 20 }
+        };
+        return dep;
+    }
+
+    function createDependencyData(
+        issues: any[],
+        recommendationRef: string,
+        remediationRef: string
+    ): DependencyData {
+        return new DependencyData(
+            'test-provider(test-source)',
+            issues,
+            recommendationRef,
+            remediationRef,
+            issues.length > 0 ? 'HIGH' : ''
+        );
+    }
+
+    setup(() => {
+        clearCodeActionsMap(mockUri);
+        globalConfig.recommendationsEnabled = true;
+        globalConfig.vulnerabilityAlertSeverity = 'Error';
+        globalConfig.trackRecommendationAcceptanceCommand = 'mockTrackCommand';
+    });
+
+    teardown(() => {
+        clearCodeActionsMap(mockUri);
+    });
+
+    /** Verifies that a recommendation-only dependency (no issues) registers a code action using recommendationRef. */
+    test('should create code action using recommendationRef when dependency has no issues', () => {
+        // Given a dependency with a recommendation but no vulnerability issues
+        const dep = createDependency('org.example:lib', '1.0.0');
+        const depMap = new DependencyMap([dep]);
+        const pipeline = new DiagnosticsPipeline(depMap, mockUri);
+
+        const recommendationRef = 'pkg:maven/org.example/lib-redhat@1.0.0.redhat-00001';
+        const dd = createDependencyData([], recommendationRef, '');
+        const dependencies = new Map<string, DependencyData[]>();
+        dependencies.set('org.example:lib@1.0.0', [dd]);
+
+        // When running diagnostics
+        pipeline.runDiagnostics(dependencies, 'maven');
+
+        // Then a code action should be registered using the recommendation ref
+        const actionsMap = getCodeActionsMap().get(mockUri.toString());
+        expect(actionsMap).to.not.be.undefined;
+        const actions = Array.from(actionsMap!.values()).flat();
+        expect(actions).to.have.lengthOf(1);
+        expect(actions[0].title).to.include('1.0.0.redhat-00001');
+    });
+
+    /** Verifies that a dependency with vulnerability issues registers a code action using remediationRef. */
+    test('should create code action using remediationRef when dependency has issues', () => {
+        // Given a dependency with vulnerability issues and a remediation
+        const dep = createDependency('org.example:lib', '1.0.0');
+        const depMap = new DependencyMap([dep]);
+        const pipeline = new DiagnosticsPipeline(depMap, mockUri);
+
+        const remediationRef = 'pkg:maven/org.example/lib@1.0.1';
+        const dd = createDependencyData(
+            [{ id: 'CVE-2024-0001', title: 'Test Vuln', severity: 'HIGH', source: 'test' }],
+            '',
+            remediationRef
+        );
+        const dependencies = new Map<string, DependencyData[]>();
+        dependencies.set('org.example:lib@1.0.0', [dd]);
+
+        // When running diagnostics
+        pipeline.runDiagnostics(dependencies, 'maven');
+
+        // Then a code action should be registered using the remediation ref
+        const actionsMap = getCodeActionsMap().get(mockUri.toString());
+        expect(actionsMap).to.not.be.undefined;
+        const actions = Array.from(actionsMap!.values()).flat();
+        expect(actions).to.have.lengthOf(1);
+        expect(actions[0].title).to.include('1.0.1');
+    });
+
+    /** Verifies that no code action is created when a recommendation-only dependency has an empty recommendationRef. */
+    test('should NOT create code action when dependency has no issues and empty recommendationRef', () => {
+        // Given a dependency with no issues and no recommendation
+        const dep = createDependency('org.example:lib', '1.0.0');
+        const depMap = new DependencyMap([dep]);
+        const pipeline = new DiagnosticsPipeline(depMap, mockUri);
+
+        const dd = createDependencyData([], '', '');
+        const dependencies = new Map<string, DependencyData[]>();
+        dependencies.set('org.example:lib@1.0.0', [dd]);
+
+        // When running diagnostics
+        pipeline.runDiagnostics(dependencies, 'maven');
+
+        // Then no code action should be registered
+        const actionsMap = getCodeActionsMap().get(mockUri.toString());
+        if (actionsMap) {
+            const actions = Array.from(actionsMap.values()).flat();
+            expect(actions).to.have.lengthOf(0);
+        }
+    });
+
+    /** Verifies that no code action is created when a dependency with issues has an empty remediationRef. */
+    test('should NOT create code action when dependency has issues and empty remediationRef', () => {
+        // Given a dependency with issues but no remediation
+        const dep = createDependency('org.example:lib', '1.0.0');
+        const depMap = new DependencyMap([dep]);
+        const pipeline = new DiagnosticsPipeline(depMap, mockUri);
+
+        const dd = createDependencyData(
+            [{ id: 'CVE-2024-0001', title: 'Test Vuln', severity: 'HIGH', source: 'test' }],
+            '',
+            ''
+        );
+        const dependencies = new Map<string, DependencyData[]>();
+        dependencies.set('org.example:lib@1.0.0', [dd]);
+
+        // When running diagnostics
+        pipeline.runDiagnostics(dependencies, 'maven');
+
+        // Then no code action should be registered
+        const actionsMap = getCodeActionsMap().get(mockUri.toString());
+        if (actionsMap) {
+            const actions = Array.from(actionsMap.values()).flat();
+            expect(actions).to.have.lengthOf(0);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Fix broken Quick Fix code action for Red Hat dependency recommendations
- Replace severity-based proxy (`severity < 3`) with direct `dd.issues.length > 0` check to correctly select between `remediationRef` and `recommendationRef`
- Remove stale TODO comment acknowledging the bug
- Add unit tests covering all four actionRef selection scenarios
- Export `DiagnosticsPipeline` for testability

## Root Cause

In `DiagnosticsPipeline.runDiagnostics()`, the condition `vulnerabilityDiagnostic.severity < 3` was used to choose between remediation and recommendation refs. Since `DiagnosticSeverity.Information` (= 2) is always < 3, the condition always selected `remediationRef` — which is empty for recommendation-only dependencies — preventing the "Switch to version X" Quick Fix from ever appearing.

## Test plan

- [x] Test: recommendation-only dependency creates code action using `recommendationRef`
- [x] Test: vulnerability dependency creates code action using `remediationRef`
- [x] Test: no code action when no issues and empty `recommendationRef`
- [x] Test: no code action when issues present and empty `remediationRef`
- [x] `npm run test-compile` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (all 4 new tests + existing tests)

Implements [TC-4662](https://redhat.atlassian.net/browse/TC-4662)

[TC-4662]: https://redhat.atlassian.net/browse/TC-4662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Fix selection of dependency diagnostic quick-fix code actions and add coverage for action reference selection logic.

Bug Fixes:
- Correct code action selection to use dependency issue presence instead of diagnostic severity when choosing between remediation and recommendation references.

Enhancements:
- Export DiagnosticsPipeline to support direct testing of the diagnostics pipeline.

Tests:
- Add unit tests covering all combinations of remediation/recommendation references and issue presence for dependency diagnostics code actions.