### PR TITLE
fix: correct license field position offset in package.json provider

### DIFF
--- a/src/providers/package.json.ts
+++ b/src/providers/package.json.ts
@@ -90,7 +90,7 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
         value: licenseNode.value.value as string,
         position: {
           line: licenseNode.value.loc!.start.line,
-          column: licenseNode.value.loc!.start.column
+          column: licenseNode.value.loc!.start.column + 1
         }
       };
     }

--- a/test/providers/license.package.json.test.ts
+++ b/test/providers/license.package.json.test.ts
@@ -26,7 +26,7 @@ suite('package.json License Field Position Extraction tests', () => {
         expect(result).to.not.be.undefined;
         expect(result?.value).to.equal('MIT');
         expect(result?.position.line).to.equal(4);
-        expect(result?.position.column).to.equal(14);
+        expect(result?.position.column).to.equal(15);
     });
 
     test('should extract license field position with different formatting', () => {


### PR DESCRIPTION
## Summary
- Fixes off-by-one error in `extractLicensePosition()` where the column pointed to the opening quote `"` instead of the first character of the license value
- This caused partial underlining of the license name and broken quick-fix replacements in JS ecosystem manifest files (NPM/PNPM/Yarn)
- Aligns with the existing `+ 1` offset used by `mapDependencies()` in the same file

## Test plan
- [x] Existing license position test updated to expect corrected column value
- [x] All 289 tests pass
- [ ] Manual verification: open a `package.json` with a license mismatch and confirm the full license name is underlined
- [ ] Manual verification: apply quick-fix and confirm the replacement produces valid JSON

Ref: TC-4697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct the reported position of the license field value in package.json providers.

Bug Fixes:
- Fix off-by-one error in the extracted column for the license value so it points to the first character instead of the opening quote.

Tests:
- Update license position extraction test expectations to match the corrected column value.