### PR TITLE
fix: upgrade lodash to 4.18.1 via npm override (CVE-2026-4800)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4657,7 +4657,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {

--- a/package.json
+++ b/package.json
@@ -574,5 +574,8 @@
     "toml-eslint-parser": "0.12.0",
     "tree-sitter-python": "^0.23.6",
     "web-tree-sitter": "^0.26.6"
+  },
+  "overrides": {
+    "lodash": "4.18.1"
   }
 }


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix lodash CVE-2026-4800 by forcing 4.18.1 via npm overrides
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

Fix [SNYK-JS-LODASH-15869625](https://security.snyk.io/vuln/SNYK-JS-LODASH-15869625) — Arbitrary Code Injection in lodash (CVE-2026-4800, High severity).

## Root Cause

`lodash@4.17.21` is a transitive dependency pulled in by:
```
@xml-tools/ast@5.0.5
├── @xml-tools/common@0.1.6
│   └── lodash@4.17.21
└── lodash@4.17.21
```

No newer version of `@xml-tools/ast` or `@xml-tools/common` is available that drops or upgrades lodash, so a direct upgrade path doesn't exist.

## Fix

Add an npm `overrides` field in `package.json` to force `lodash@4.18.1` for all transitive consumers:

```json
"overrides": {
  "lodash": "4.18.1"
}
```

## Verification

- `npm ls lodash --all` confirms `lodash@4.18.1 overridden`
- `npm run test-compile` passes (TypeScript compilation successful)
- No source code changes — lodash is not imported directly

## Related

- [CVE-2026-4800](https://security.snyk.io/vuln/SNYK-JS-LODASH-15869625) — Arbitrary Code Injection
- [CVE-2026-2950](https://security.snyk.io/vuln/SNYK-JS-LODASH-15869619) — Prototype Pollution (also fixed by 4.18.1)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Force transitive lodash to 4.18.1 using npm overrides
• Remediate high-severity lodash code injection (CVE-2026-4800)
• Avoid direct dependency churn since upstream @xml-tools packages cannot upgrade
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  PKG["package.json"] --> NPM(["npm install / overrides"]) --> AST["@xml-tools/ast"] --> LOD["lodash@4.18.1"]
  NPM --> COM["@xml-tools/common"] --> LOD
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Upgrade upstream transitive packages</b></summary>

- ➕ Removes the need for an override long-term
- ➕ Lets upstream manage compatibility and future patching
- ➖ No available @xml-tools/ast/@xml-tools/common release that upgrades/drops lodash (per PR context)
- ➖ Still requires waiting on upstream release cadence

</details>

<details>
<summary><b>2. Fork/replace @xml-tools/* dependency</b></summary>

- ➕ Full control over transitive dependency tree
- ➕ Can permanently eliminate vulnerable transitive dependency sources
- ➖ High maintenance burden and divergence risk
- ➖ Larger change surface than needed for a security remediation

</details>

<details>
<summary><b>3. Use patch-package / direct vendoring</b></summary>

- ➕ Works even when override mechanisms are unavailable
- ➕ Can apply targeted changes beyond version pinning
- ➖ More brittle across installs/lockfile changes
- ➖ Harder to audit than a standard override/pin

</details>

**Recommendation:** Keep the npm overrides approach: it is the smallest effective remediation given the lack of upstream upgrades, and it is easy to audit and revert. Add a follow-up to periodically re-check @xml-tools/* for releases that remove the need for the override.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>package.json</strong> <code>Add npm override to force lodash 4.18.1</code> <code>+3/-0</code></summary>

<br/>

>Add npm override to force lodash 4.18.1
>
><pre>
>• Introduces an npm &quot;overrides&quot; entry to pin lodash to 4.18.1 across all transitive dependencies. This mitigates the reported lodash vulnerabilities without changing application source imports.
></pre>
>
><a href='https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/909/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519'>package.json</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>