### PR TITLE
feat: read provider-level recommendations map in diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
-        "@trustify-da/trustify-da-api-model": "^2.0.7",
-        "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.d2edf6e",
+        "@trustify-da/trustify-da-api-model": "^2.0.8",
+        "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.b68592e",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "cli-table3": "^0.6.5",
@@ -888,7 +888,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@trustify-da/trustify-da-api-model": {
-      "version": "2.0.7",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-api-model/-/trustify-da-api-model-2.0.8.tgz",
+      "integrity": "sha512-i4wVuNzWg8ASPOKpeiuuMD9SJaYDlqWCDApknMRuskP9QBSMnAORtbzoFXBNoMXWPVYGI8SrSpfF3J7fAPvzIw==",
       "license": "Apache-2.0"
     },
     "node_modules/@trustify-da/trustify-da-javascript-client": {

--- a/package.json
+++ b/package.json
@@ -559,8 +559,8 @@
   },
   "dependencies": {
     "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
-    "@trustify-da/trustify-da-api-model": "^2.0.7",
-    "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.d2edf6e",
+    "@trustify-da/trustify-da-api-model": "^2.0.8",
+    "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.b68592e",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "^1.0.11",
     "cli-table3": "^0.6.5",

--- a/src/dependencyAnalysis/analysis.ts
+++ b/src/dependencyAnalysis/analysis.ts
@@ -32,6 +32,7 @@ interface ComponentAnalysisResult extends AnalysisReport {
 interface ISource {
   id: string;
   dependencies: DependencyReport[];
+  hasProviderRecommendations: boolean;
 }
 
 export interface ResponseMetrics {
@@ -68,7 +69,8 @@ class DependencyData {
     public recommendationRef: string,
     public remediationRef: string,
     public highestVulnerabilitySeverity: string,
-    public packageManager: string = ''
+    public packageManager: string = '',
+    public recommendationSourceId: string = ''
   ) { }
 }
 
@@ -107,9 +109,15 @@ class AnalysisResponse {
       Object.entries(resData.providers).map(([providerName, providerData]) => {
         this.metrics.providers[providerName] = {};
         if (isDefined(providerData, 'status', 'ok') && providerData.status.ok) {
+          const hasProviderRecommendations = isDefined(providerData, 'recommendations');
+
           if (isDefined(providerData, 'sources')) {
             Object.entries(providerData.sources).map(([sourceName, sourceData]) => {
-              sources.push({ id: `${providerName}(${sourceName})`, dependencies: this.getDependencies(sourceData) });
+              sources.push({
+                id: `${providerName}(${sourceName})`,
+                dependencies: this.getDependencies(sourceData),
+                hasProviderRecommendations,
+              });
 
               if (isDefined(sourceData, 'summary')) {
                 this.metrics.providers[providerName][sourceName] = {
@@ -124,6 +132,30 @@ class AnalysisResponse {
                   remediations: sourceData.summary.remediations ?? 0,
                   total: sourceData.summary.total ?? 0,
                 };
+              }
+            });
+          }
+
+          if (hasProviderRecommendations) {
+            Object.entries(providerData.recommendations).map(([recSourceName, recSourceData]) => {
+              if (recSourceData.dependencies) {
+                recSourceData.dependencies.forEach(recReport => {
+                  if (isDefined(recReport, 'ref') && isDefined(recReport, 'recommendation')) {
+                    const resolvedRef = this.provider.resolveDependencyFromReference(recReport.ref);
+                    const recommendationRef = this.provider.resolveDependencyFromReference(recReport.recommendation.split('?')[0]);
+                    const dd = new DependencyData(
+                      providerName,
+                      [],
+                      recommendationRef,
+                      '',
+                      'NONE',
+                      packageManager,
+                      recSourceName
+                    );
+                    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                    this.dependencies.get(resolvedRef)?.push(dd) || this.dependencies.set(resolvedRef, [dd]);
+                  }
+                });
               }
             });
           }
@@ -144,12 +176,16 @@ class AnalysisResponse {
       sources.forEach(source => {
         source.dependencies.forEach(d => {
           if (isDefined(d, 'ref')) {
-
             const issues = isDefined(d, 'issues') ? d.issues : [];
 
-            const dd = issues.length
-              ? new DependencyData(source.id, issues, '', this.getRemediation(issues[0]), this.getHighestSeverity(d))
-              : new DependencyData(source.id, issues, this.getRecommendation(d), '', this.getHighestSeverity(d), packageManager);
+            let dd: DependencyData;
+            if (issues.length) {
+              dd = new DependencyData(source.id, issues, '', this.getRemediation(issues[0]), this.getHighestSeverity(d));
+            } else if (!source.hasProviderRecommendations) {
+              dd = new DependencyData(source.id, issues, this.getRecommendation(d), '', this.getHighestSeverity(d), packageManager);
+            } else {
+              return;
+            }
 
             const resolvedRef = this.provider.resolveDependencyFromReference(d.ref);
             // eslint-disable-next-line @typescript-eslint/no-unused-expressions

--- a/src/dependencyAnalysis/diagnostics.ts
+++ b/src/dependencyAnalysis/diagnostics.ts
@@ -69,7 +69,7 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<DependencyData> {
             ? dd.recommendationRef
             : dd.remediationRef;
           if (actionRef) {
-            this.createCodeAction(dependency, loc, actionRef, dependency.context, dd.sourceId, vulnerabilityDiagnostic);
+            this.createCodeAction(dependency, loc, actionRef, dependency.context, dd.sourceId, vulnerabilityDiagnostic, dd.recommendationSourceId);
           }
 
           for (const vuln of dd.issues) {
@@ -89,12 +89,15 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<DependencyData> {
    * @param context - Dependency context object.
    * @param sourceId - Source ID.
    * @param vulnerabilityDiagnostic - Vulnerability diagnostic object.
+   * @param recommendationSourceId - Optional recommendation source identifier.
    * @private
    */
-  private createCodeAction(dependency: Dependency, loc: string, ref: string, context: IPositionedContext | undefined, sourceId: string, vulnerabilityDiagnostic: Diagnostic) {
+  private createCodeAction(dependency: Dependency, loc: string, ref: string, context: IPositionedContext | undefined, sourceId: string, vulnerabilityDiagnostic: Diagnostic, recommendationSourceId: string = '') {
     const switchToVersion = ref.split('@')[1];
     const versionReplacementString = context ? context.value.replace(VERSION_PLACEHOLDER, switchToVersion) : switchToVersion;
-    const title = `Switch to version ${switchToVersion} for ${sourceId}`;
+    const title = recommendationSourceId
+      ? `Switch to version ${switchToVersion} (${recommendationSourceId})`
+      : `Switch to version ${switchToVersion} for ${sourceId}`;
     const codeAction = generateSwitchToRecommendedVersionAction(title, ref, versionReplacementString, vulnerabilityDiagnostic, this.diagnosticFilePath, dependency.version);
     registerCodeAction(this.diagnosticFilePath, loc, codeAction);
   }

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -16,6 +16,7 @@ import { notifications, outputChannelDep } from '../extension';
 import { imageAnalysisService } from '../exhortServices';
 import { type IOptions } from '../imageAnalysis';
 import { Issue } from '@trustify-da/trustify-da-api-model/model/v5/Issue';
+import { PackageURL } from 'packageurl-js';
 
 /**
  * Represents the Red Hat Dependency Analytics (RHDA) analysis report, with images mapped by string keys.
@@ -34,20 +35,18 @@ interface IArtifact {
 }
 
 /**
- * Extracts the namespace/name portion from a PURL string, stripping the
- * `pkg:<type>/` prefix and `@<version>` suffix. Handles PURLs with
- * multiple colons (e.g., registry ports, sha256 digests).
+ * Extracts the namespace/name image reference from a PURL string using the
+ * spec-compliant `packageurl-js` library.
  * @param purl - A Package URL string (e.g., `pkg:docker/nginx@1.25`).
  * @returns The namespace/name portion (e.g., `nginx`), or empty string if invalid.
  */
 function parseImageRefFromPurl(purl: string): string {
-  const slashIndex = purl.indexOf('/');
-  if (slashIndex === -1) {
+  try {
+    const parsed = PackageURL.fromString(purl);
+    return [parsed.namespace, parsed.name].filter(Boolean).join('/');
+  } catch {
     return '';
   }
-  const withoutPrefix = purl.substring(slashIndex + 1);
-  const atIndex = withoutPrefix.indexOf('@');
-  return atIndex === -1 ? withoutPrefix : withoutPrefix.substring(0, atIndex);
 }
 
 class ImageData {
@@ -202,4 +201,4 @@ async function executeImageAnalysis(diagnosticFilePath: Uri, images: IImage[], o
   return new AnalysisResponse(imageAnalysisJson, diagnosticFilePath);
 }
 
-export { executeImageAnalysis, AnalysisResponse, ImageData, parseImageRefFromPurl };
+export { executeImageAnalysis, AnalysisResponse, ImageData };

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -67,12 +67,12 @@ class AnalysisResponse {
     const failedProviders: string[] = [];
 
     Object.entries(resData).map(([imageRef, imageData]) => {
-      const artifacts: IArtifact[] = [];
-      let hasProviderRecommendations = false;
-
       if (isDefined(imageData, 'providers')) {
         Object.entries(imageData.providers).map(([providerName, providerData]: [string, ProviderReport]) => {
           if (providerData?.status?.ok) {
+            const artifacts: IArtifact[] = [];
+            let hasProviderRecommendations = false;
+
             if (isDefined(providerData, 'sources')) {
               Object.entries(providerData.sources).map(([sourceName, sourceData]: [string, Source]) => {
                 if (isDefined(sourceData, 'summary')) {
@@ -109,22 +109,22 @@ class AnalysisResponse {
                 }
               });
             }
+
+            artifacts.forEach(artifact => {
+              const sd = new ImageData(
+                artifact.id,
+                artifact.dependencies?.flatMap(dependency => dependency.issues || []) || [],
+                hasProviderRecommendations ? '' : this.getRecommendation(artifact.dependencies),
+                this.getHighestSeverity(artifact.summary),
+              );
+
+              const dataArray = this.images.get(imageRef) || [];
+              dataArray.push(sd);
+              this.images.set(imageRef, dataArray);
+            });
           } else {
             failedProviders.push(providerName);
           }
-        });
-
-        artifacts.forEach(artifact => {
-          const sd = new ImageData(
-            artifact.id,
-            artifact.dependencies?.flatMap(dependency => dependency.issues || []) || [],
-            hasProviderRecommendations ? '' : this.getRecommendation(artifact.dependencies),
-            this.getHighestSeverity(artifact.summary),
-          );
-
-          const dataArray = this.images.get(imageRef) || [];
-          dataArray.push(sd);
-          this.images.set(imageRef, dataArray);
         });
       }
 
@@ -202,4 +202,4 @@ async function executeImageAnalysis(diagnosticFilePath: Uri, images: IImage[], o
   return new AnalysisResponse(imageAnalysisJson, diagnosticFilePath);
 }
 
-export { executeImageAnalysis, ImageData, parseImageRefFromPurl };
+export { executeImageAnalysis, AnalysisResponse, ImageData, parseImageRefFromPurl };

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -38,7 +38,8 @@ class ImageData {
     public sourceId: string,
     public issues: Issue[],
     public recommendationRef: string,
-    public highestVulnerabilitySeverity: string
+    public highestVulnerabilitySeverity: string,
+    public recommendationSourceId: string = ''
   ) { }
 }
 
@@ -50,6 +51,7 @@ class AnalysisResponse {
 
     Object.entries(resData).map(([imageRef, imageData]) => {
       const artifacts: IArtifact[] = [];
+      let hasProviderRecommendations = false;
 
       if (isDefined(imageData, 'providers')) {
         Object.entries(imageData.providers).map(([providerName, providerData]: [string, ProviderReport]) => {
@@ -65,6 +67,31 @@ class AnalysisResponse {
                 }
               });
             }
+
+            if (isDefined(providerData, 'recommendations')) {
+              hasProviderRecommendations = true;
+              Object.entries(providerData.recommendations).map(([recSourceName, recSourceData]) => {
+                if (recSourceData.dependencies) {
+                  recSourceData.dependencies.forEach(recReport => {
+                    if (recReport.recommendation) {
+                      const recommendationRef = recReport.recommendation.split(':')[1]?.split('@')[0] || '';
+                      if (recommendationRef) {
+                        const sd = new ImageData(
+                          providerName,
+                          [],
+                          recommendationRef,
+                          'NONE',
+                          recSourceName
+                        );
+                        const dataArray = this.images.get(imageRef) || [];
+                        dataArray.push(sd);
+                        this.images.set(imageRef, dataArray);
+                      }
+                    }
+                  });
+                }
+              });
+            }
           } else {
             failedProviders.push(providerName);
           }
@@ -74,7 +101,7 @@ class AnalysisResponse {
           const sd = new ImageData(
             artifact.id,
             artifact.dependencies?.flatMap(dependency => dependency.issues || []) || [],
-            this.getRecommendation(artifact.dependencies),
+            hasProviderRecommendations ? '' : this.getRecommendation(artifact.dependencies),
             this.getHighestSeverity(artifact.summary),
           );
 

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -33,6 +33,23 @@ interface IArtifact {
   dependencies: DependencyReport[] | undefined;
 }
 
+/**
+ * Extracts the namespace/name portion from a PURL string, stripping the
+ * `pkg:<type>/` prefix and `@<version>` suffix. Handles PURLs with
+ * multiple colons (e.g., registry ports, sha256 digests).
+ * @param purl - A Package URL string (e.g., `pkg:docker/nginx@1.25`).
+ * @returns The namespace/name portion (e.g., `nginx`), or empty string if invalid.
+ */
+function parseImageRefFromPurl(purl: string): string {
+  const slashIndex = purl.indexOf('/');
+  if (slashIndex === -1) {
+    return '';
+  }
+  const withoutPrefix = purl.substring(slashIndex + 1);
+  const atIndex = withoutPrefix.indexOf('@');
+  return atIndex === -1 ? withoutPrefix : withoutPrefix.substring(0, atIndex);
+}
+
 class ImageData {
   constructor(
     public sourceId: string,
@@ -74,7 +91,7 @@ class AnalysisResponse {
                 if (recSourceData.dependencies) {
                   recSourceData.dependencies.forEach(recReport => {
                     if (recReport.recommendation) {
-                      const recommendationRef = recReport.recommendation.split(':')[1]?.split('@')[0] || '';
+                      const recommendationRef = parseImageRefFromPurl(recReport.recommendation);
                       if (recommendationRef) {
                         const sd = new ImageData(
                           providerName,
@@ -164,7 +181,7 @@ class AnalysisResponse {
   private getRecommendation(dependencies: DependencyReport[] | undefined): string {
     let recommendation = '';
     if (dependencies && dependencies.length > 0) {
-      recommendation = isDefined(dependencies[0], 'recommendation') ? dependencies[0].recommendation.split(':')[1].split('@')[0] : '';
+      recommendation = isDefined(dependencies[0], 'recommendation') ? parseImageRefFromPurl(dependencies[0].recommendation) : '';
     }
     return recommendation;
   }
@@ -185,4 +202,4 @@ async function executeImageAnalysis(diagnosticFilePath: Uri, images: IImage[], o
   return new AnalysisResponse(imageAnalysisJson, diagnosticFilePath);
 }
 
-export { executeImageAnalysis, ImageData };
+export { executeImageAnalysis, ImageData, parseImageRefFromPurl };

--- a/src/imageAnalysis/diagnostics.ts
+++ b/src/imageAnalysis/diagnostics.ts
@@ -54,7 +54,7 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
 
         imageData.forEach(id => {
           if (id.recommendationRef && globalConfig.recommendationsEnabled) {
-            this.createCodeAction(loc, id.recommendationRef, id.sourceId, vulnerabilityDiagnostic);
+            this.createCodeAction(loc, id.recommendationRef, id.sourceId, vulnerabilityDiagnostic, id.recommendationSourceId);
           }
 
           for (const vuln of id.issues) {
@@ -74,10 +74,14 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
    * @param imageRef - The reference name of the image.
    * @param sourceId - Source ID.
    * @param vulnerabilityDiagnostic - Vulnerability diagnostic object.
+   * @param recommendationSourceId - Optional recommendation source identifier.
    * @private
    */
-  private createCodeAction(loc: string, imageRef: string, sourceId: string, vulnerabilityDiagnostic: Diagnostic) {
-    const title = `${sourceId}: Switch to Red Hat UBI ${imageRef} for enhanced security and enterprise-grade stability`;
+  private createCodeAction(loc: string, imageRef: string, sourceId: string, vulnerabilityDiagnostic: Diagnostic, recommendationSourceId: string = '') {
+    const sourceLabel = recommendationSourceId
+      ? `${sourceId} (${recommendationSourceId})`
+      : sourceId;
+    const title = `${sourceLabel}: Switch to Red Hat UBI ${imageRef} for enhanced security and enterprise-grade stability`;
     const codeAction = generateRedirectToRecommendedVersionAction(title, imageRef, vulnerabilityDiagnostic, this.diagnosticFilePath);
     registerCodeAction(this.diagnosticFilePath, loc, codeAction);
   }

--- a/src/vulnerability.ts
+++ b/src/vulnerability.ts
@@ -62,11 +62,25 @@ Highest severity: ${artifactData.highestVulnerabilitySeverity}`;
   }
 
   /**
-   * Generate recommendation message from source
+   * Generate recommendation message from source.
+   * Uses the recommendation source label when available (provider-level recommendations),
+   * otherwise falls back to the deprecated per-source format.
    * @param artifactData Properties of the artifact object
    * @returns source recommendation message string
    */
   private generateRecommendation(artifactData: DependencyData | ImageData): string {
+    if (artifactData.recommendationSourceId) {
+      let base = `${artifactData.sourceId} ${artifactData.recommendationSourceId} recommendation:\n${artifactData.recommendationRef}`;
+
+      if (artifactData.recommendationSourceId === 'trusted-libraries' && 'packageManager' in artifactData && artifactData.packageManager && artifactData.recommendationRef) {
+        const instructions = getTrustedRegistryInstructions(artifactData.packageManager as pythonPackageManager);
+        if (instructions) {
+          base = `${base}\n\n${instructions}`;
+        }
+      }
+      return base;
+    }
+
     const base = `${artifactData.sourceId} vulnerability info:
 Known security vulnerabilities: ${artifactData.issues.length}
 Recommendation: ${artifactData.recommendationRef || 'No Red Hat recommendations'}`;

--- a/test/codeActionHandler.test.ts
+++ b/test/codeActionHandler.test.ts
@@ -341,4 +341,34 @@ suite('Code Action Handler tests', () => {
         expect(actionRef).to.equal(remediationRef);
         expect(actionRef).to.not.equal('');
     });
+
+    /**
+     * Verifies that code action uses the correct recommendation ref per source type
+     * when recommendationSourceId is set on the DependencyData.
+     */
+    test('should select correct recommendationRef per recommendation source type', async () => {
+        // Given multiple recommendation sources for the same dependency
+        config.globalConfig.recommendationsEnabled = true;
+
+        const trustedContentRef = 'mockPackage@2.0.0';
+        const trustedLibrariesRef = 'mockPackage@2.0.0-rh';
+        const dependencyData = [
+            new DependencyData('rhtpa', [], trustedContentRef, '', 'NONE', '', 'trusted-content'),
+            new DependencyData('rhtpa', [], trustedLibrariesRef, '', 'NONE', '', 'trusted-libraries')
+        ];
+        const range = new Range(new Position(10, 5), new Position(10, 15));
+        const vulnerability = new Vulnerability(range, 'mockPackage@1.0.0', dependencyData);
+
+        // When getting the diagnostic
+        const diagnostic = vulnerability.getDiagnostic();
+
+        // Then severity should be Information (recommendation-only)
+        expect(diagnostic.severity).to.eql(DiagnosticSeverity.Information);
+
+        // Then each entry should have its own recommendation ref
+        expect(dependencyData[0].recommendationRef).to.equal(trustedContentRef);
+        expect(dependencyData[0].recommendationSourceId).to.equal('trusted-content');
+        expect(dependencyData[1].recommendationRef).to.equal(trustedLibrariesRef);
+        expect(dependencyData[1].recommendationSourceId).to.equal('trusted-libraries');
+    });
 });

--- a/test/imageAnalysis.test.ts
+++ b/test/imageAnalysis.test.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 import * as exhortServices from '../src/exhortServices';
 import { globalConfig } from '../src/config';
 import { executeDockerImageAnalysis } from '../src/imageAnalysis';
+import { parseImageRefFromPurl } from '../src/imageAnalysis/analysis';
 import * as rhda from '../src/rhda';
 import { DepOutputChannel } from '../src/depOutputChannel';
 import { MockTokenProvider } from '../src/tokenProvider';
@@ -86,5 +87,52 @@ FROM stage1 AS runner
                 expect(error.message).to.eq('Mock Error');
                 expect(updateCurrentWebviewPanelSpy.calledOnceWithExactly('error')).to.be.true;
             });
+    });
+});
+
+suite('parseImageRefFromPurl', () => {
+    const cases: { input: string; expected: string; description: string }[] = [
+        {
+            input: 'pkg:docker/nginx@1.25',
+            expected: 'nginx',
+            description: 'should parse simple image PURL',
+        },
+        {
+            input: 'pkg:docker/library/nginx@1.25',
+            expected: 'library/nginx',
+            description: 'should parse namespaced image PURL',
+        },
+        {
+            input: 'pkg:docker/registry.example.com:5000/myimage@1.0',
+            expected: 'registry.example.com:5000/myimage',
+            description: 'should handle registry-qualified PURLs with port colons',
+        },
+        {
+            input: 'pkg:docker/image@sha256:abc123',
+            expected: 'image',
+            description: 'should handle PURLs with sha256 digest in version',
+        },
+        {
+            input: 'pkg:oci/ubi9/ubi-minimal@9.4',
+            expected: 'ubi9/ubi-minimal',
+            description: 'should parse OCI-type PURLs',
+        },
+        {
+            input: 'pkg:docker/registry.io:443/org/image@2.0?os=linux',
+            expected: 'registry.io:443/org/image',
+            description: 'should handle port, namespace, and query params',
+        },
+        {
+            input: 'invalidpurl',
+            expected: '',
+            description: 'should return empty string for PURL without slash',
+        },
+    ];
+
+    cases.forEach(({ input, expected, description }) => {
+        /** Verifies PURL parsing for: ${description} */
+        test(description, () => {
+            expect(parseImageRefFromPurl(input)).to.equal(expected);
+        });
     });
 });

--- a/test/imageAnalysis.test.ts
+++ b/test/imageAnalysis.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import * as exhortServices from '../src/exhortServices';
 import { globalConfig } from '../src/config';
 import { executeDockerImageAnalysis } from '../src/imageAnalysis';
-import { parseImageRefFromPurl, AnalysisResponse } from '../src/imageAnalysis/analysis';
+import { AnalysisResponse } from '../src/imageAnalysis/analysis';
 import { Uri } from 'vscode';
 import * as rhda from '../src/rhda';
 import { DepOutputChannel } from '../src/depOutputChannel';
@@ -88,53 +88,6 @@ FROM stage1 AS runner
                 expect(error.message).to.eq('Mock Error');
                 expect(updateCurrentWebviewPanelSpy.calledOnceWithExactly('error')).to.be.true;
             });
-    });
-});
-
-suite('parseImageRefFromPurl', () => {
-    const cases: { input: string; expected: string; description: string }[] = [
-        {
-            input: 'pkg:docker/nginx@1.25',
-            expected: 'nginx',
-            description: 'should parse simple image PURL',
-        },
-        {
-            input: 'pkg:docker/library/nginx@1.25',
-            expected: 'library/nginx',
-            description: 'should parse namespaced image PURL',
-        },
-        {
-            input: 'pkg:docker/registry.example.com:5000/myimage@1.0',
-            expected: 'registry.example.com:5000/myimage',
-            description: 'should handle registry-qualified PURLs with port colons',
-        },
-        {
-            input: 'pkg:docker/image@sha256:abc123',
-            expected: 'image',
-            description: 'should handle PURLs with sha256 digest in version',
-        },
-        {
-            input: 'pkg:oci/ubi9/ubi-minimal@9.4',
-            expected: 'ubi9/ubi-minimal',
-            description: 'should parse OCI-type PURLs',
-        },
-        {
-            input: 'pkg:docker/registry.io:443/org/image@2.0?os=linux',
-            expected: 'registry.io:443/org/image',
-            description: 'should handle port, namespace, and query params',
-        },
-        {
-            input: 'invalidpurl',
-            expected: '',
-            description: 'should return empty string for PURL without slash',
-        },
-    ];
-
-    cases.forEach(({ input, expected, description }) => {
-        /** Verifies PURL parsing for: ${description} */
-        test(description, () => {
-            expect(parseImageRefFromPurl(input)).to.equal(expected);
-        });
     });
 });
 

--- a/test/imageAnalysis.test.ts
+++ b/test/imageAnalysis.test.ts
@@ -7,7 +7,8 @@ import * as fs from 'fs';
 import * as exhortServices from '../src/exhortServices';
 import { globalConfig } from '../src/config';
 import { executeDockerImageAnalysis } from '../src/imageAnalysis';
-import { parseImageRefFromPurl } from '../src/imageAnalysis/analysis';
+import { parseImageRefFromPurl, AnalysisResponse } from '../src/imageAnalysis/analysis';
+import { Uri } from 'vscode';
 import * as rhda from '../src/rhda';
 import { DepOutputChannel } from '../src/depOutputChannel';
 import { MockTokenProvider } from '../src/tokenProvider';
@@ -134,5 +135,87 @@ suite('parseImageRefFromPurl', () => {
         test(description, () => {
             expect(parseImageRefFromPurl(input)).to.equal(expected);
         });
+    });
+});
+
+suite('AnalysisResponse provider scoping', () => {
+    /**
+     * Verifies that hasProviderRecommendations is scoped per-provider, not per-image.
+     * When one provider has recommendations and another does not, the provider without
+     * recommendations should use the deprecated fallback for its artifacts.
+     */
+    test('should scope hasProviderRecommendations per-provider so deprecated fallback works for provider without recommendations', () => {
+        // Given two providers for the same image:
+        // - providerA has recommendations (should suppress deprecated fallback)
+        // - providerB has NO recommendations (should use deprecated fallback)
+        const mockData = {
+            'docker.io/nginx:1.25': {
+                providers: {
+                    providerA: {
+                        status: { ok: true },
+                        sources: {
+                            sourceA: {
+                                summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0 },
+                                dependencies: [{
+                                    ref: 'pkg:docker/nginx@1.25',
+                                    recommendation: 'pkg:docker/nginx@1.26',
+                                    issues: [],
+                                }],
+                            },
+                        },
+                        recommendations: {
+                            'trusted-content': {
+                                dependencies: [{
+                                    ref: 'pkg:docker/nginx@1.25',
+                                    recommendation: 'pkg:docker/ubi9/nginx@1.26',
+                                }],
+                            },
+                        },
+                    },
+                    providerB: {
+                        status: { ok: true },
+                        sources: {
+                            sourceB: {
+                                summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0 },
+                                dependencies: [{
+                                    ref: 'pkg:docker/nginx@1.25',
+                                    recommendation: 'pkg:docker/nginx@1.27',
+                                    issues: [{ id: 'CVE-2024-001', severity: 'HIGH' }],
+                                }],
+                            },
+                        },
+                        // No recommendations map — should use deprecated fallback
+                    },
+                },
+            },
+        };
+
+        // When constructing AnalysisResponse
+        const response = new AnalysisResponse(mockData as any, Uri.file('/mock/Dockerfile'));
+
+        // Then the image should have data from both providers
+        const imageDataList = response.images.get('docker.io/nginx:1.25');
+        expect(imageDataList).to.not.be.undefined;
+
+        // providerA's trusted-content recommendation (from recommendations map)
+        const providerARecommendation = imageDataList!.find(
+            d => d.sourceId === 'providerA' && d.recommendationSourceId === 'trusted-content'
+        );
+        expect(providerARecommendation).to.not.be.undefined;
+        expect(providerARecommendation!.recommendationRef).to.equal('ubi9/nginx');
+
+        // providerA's artifact should have empty recommendationRef (suppressed by provider recommendations)
+        const providerAArtifact = imageDataList!.find(
+            d => d.sourceId === 'providerA(sourceA)' && d.recommendationSourceId === ''
+        );
+        expect(providerAArtifact).to.not.be.undefined;
+        expect(providerAArtifact!.recommendationRef).to.equal('');
+
+        // providerB's artifact should use deprecated fallback (non-empty recommendationRef)
+        const providerBArtifact = imageDataList!.find(
+            d => d.sourceId === 'providerB(sourceB)' && d.recommendationSourceId === ''
+        );
+        expect(providerBArtifact).to.not.be.undefined;
+        expect(providerBArtifact!.recommendationRef).to.equal('nginx');
     });
 });

--- a/test/vulnerability.test.ts
+++ b/test/vulnerability.test.ts
@@ -27,7 +27,8 @@ suite('Vulnerability tests', () => {
             public recommendationRef: string,
             public remediationRef: string,
             public highestVulnerabilitySeverity: string,
-            public packageManager: string = ''
+            public packageManager: string = '',
+            public recommendationSourceId: string = ''
         ) { }
     }
 
@@ -36,7 +37,8 @@ suite('Vulnerability tests', () => {
             public sourceId: string,
             public issues: Issue[],
             public recommendationRef: string,
-            public highestVulnerabilitySeverity: string
+            public highestVulnerabilitySeverity: string,
+            public recommendationSourceId: string = ''
         ) { }
     }
 
@@ -383,5 +385,159 @@ suite('Vulnerability tests', () => {
         expect(diagnostic.message).to.not.include('tool.uv.index');
         expect(diagnostic.message).to.not.include('poetry source add');
         expect(diagnostic.message).to.not.include(REDHAT_TRUSTED_PYTHON_REGISTRY_URL);
+    });
+
+    /**
+     * Verifies that a single recommendation source produces a diagnostic message
+     * with the correct source label format.
+     */
+    test('should return diagnostic with provider-level recommendation source label', async () => {
+        config.globalConfig.recommendationsEnabled = true;
+
+        const mockDependencyData: MockDependencyData[] = [
+            new MockDependencyData('rhtpa', [], mockRecommendationRef, '', 'NONE', '', 'trusted-content')
+        ];
+        const vulnerability = new Vulnerability(
+            mockRange,
+            mockMavenRef,
+            mockDependencyData
+        );
+
+        const diagnostic = vulnerability.getDiagnostic();
+        expect(diagnostic.message).to.include('rhtpa trusted-content recommendation:');
+        expect(diagnostic.message).to.include(mockRecommendationRef);
+        expect(diagnostic.severity).to.eql(DiagnosticSeverity.Information);
+    });
+
+    /**
+     * Verifies that multiple recommendation sources produce separate messages
+     * within the same diagnostic for the same dependency.
+     */
+    test('should return diagnostic with multiple recommendation sources for same dependency', async () => {
+        config.globalConfig.recommendationsEnabled = true;
+
+        const mockDependencyData: MockDependencyData[] = [
+            new MockDependencyData('rhtpa', [], mockRecommendationRef, '', 'NONE', '', 'trusted-content'),
+            new MockDependencyData('rhtpa', [], 'mockGroupId1/mockArtifact1@mockTrustedLibVersion', '', 'NONE', '', 'trusted-libraries')
+        ];
+        const vulnerability = new Vulnerability(
+            mockRange,
+            mockMavenRef,
+            mockDependencyData
+        );
+
+        const diagnostic = vulnerability.getDiagnostic();
+        expect(diagnostic.message).to.include('rhtpa trusted-content recommendation:');
+        expect(diagnostic.message).to.include(mockRecommendationRef);
+        expect(diagnostic.message).to.include('rhtpa trusted-libraries recommendation:');
+        expect(diagnostic.message).to.include('mockGroupId1/mockArtifact1@mockTrustedLibVersion');
+        expect(diagnostic.severity).to.eql(DiagnosticSeverity.Information);
+    });
+
+    /**
+     * Verifies that a recommendation-only dependency (no vulnerabilities) with
+     * a recommendation source shows Information severity.
+     */
+    test('should return Information severity for recommendation-only dependency with source label', async () => {
+        config.globalConfig.recommendationsEnabled = true;
+
+        const mockDependencyData: MockDependencyData[] = [
+            new MockDependencyData('rhtpa', [], mockRecommendationRef, '', 'NONE', '', 'trusted-content')
+        ];
+        const vulnerability = new Vulnerability(
+            mockRange,
+            mockMavenRef,
+            mockDependencyData
+        );
+
+        const diagnostic = vulnerability.getDiagnostic();
+        expect(diagnostic.severity).to.eql(DiagnosticSeverity.Information);
+        expect(diagnostic.message).to.not.include('vulnerability info:');
+    });
+
+    /**
+     * Verifies that the deprecated fallback format (without recommendationSourceId)
+     * still works when provider-level recommendations are absent.
+     */
+    test('should return diagnostic with deprecated format when recommendationSourceId is empty', async () => {
+        config.globalConfig.recommendationsEnabled = true;
+
+        const mockDependencyData: MockDependencyData[] = [
+            new MockDependencyData('tpa(tpa)', [], mockRecommendationRef, '', 'NONE')
+        ];
+        const vulnerability = new Vulnerability(
+            mockRange,
+            mockMavenRef,
+            mockDependencyData
+        );
+
+        const diagnostic = vulnerability.getDiagnostic();
+        expect(diagnostic.message).to.include('tpa(tpa) vulnerability info:');
+        expect(diagnostic.message).to.include('Recommendation: ' + mockRecommendationRef);
+    });
+
+    /**
+     * Verifies that image recommendations read from provider level
+     * display the correct source label in the diagnostic message.
+     */
+    test('should return diagnostic with provider-level recommendation for image data', async () => {
+        config.globalConfig.recommendationsEnabled = true;
+
+        const mockImageData: MockImageData[] = [
+            new MockImageData('rhtpa', [], 'ubi8/openjdk-11', 'NONE', 'hardened-images')
+        ];
+        const vulnerability = new Vulnerability(
+            mockRange,
+            mockImageRef,
+            mockImageData
+        );
+
+        const diagnostic = vulnerability.getDiagnostic();
+        expect(diagnostic.message).to.include('rhtpa hardened-images recommendation:');
+        expect(diagnostic.message).to.include('ubi8/openjdk-11');
+        expect(diagnostic.severity).to.eql(DiagnosticSeverity.Information);
+    });
+
+    /**
+     * Verifies that trusted registry instructions appear only for
+     * the trusted-libraries recommendation source, not for other sources.
+     */
+    test('should include trusted registry instructions only for trusted-libraries source', async () => {
+        config.globalConfig.recommendationsEnabled = true;
+
+        const mockDependencyData: MockDependencyData[] = [
+            new MockDependencyData('rhtpa', [], mockRecommendationRef, '', 'NONE', 'pip', 'trusted-libraries')
+        ];
+        const vulnerability = new Vulnerability(
+            mockRange,
+            mockMavenRef,
+            mockDependencyData
+        );
+
+        const diagnostic = vulnerability.getDiagnostic();
+        expect(diagnostic.message).to.include('rhtpa trusted-libraries recommendation:');
+        expect(diagnostic.message).to.include('pip.conf');
+        expect(diagnostic.message).to.include(REDHAT_TRUSTED_PYTHON_REGISTRY_URL);
+    });
+
+    /**
+     * Verifies that trusted registry instructions are NOT included for
+     * the trusted-content recommendation source even when packageManager is set.
+     */
+    test('should not include trusted registry instructions for trusted-content source', async () => {
+        config.globalConfig.recommendationsEnabled = true;
+
+        const mockDependencyData: MockDependencyData[] = [
+            new MockDependencyData('rhtpa', [], mockRecommendationRef, '', 'NONE', 'pip', 'trusted-content')
+        ];
+        const vulnerability = new Vulnerability(
+            mockRange,
+            mockMavenRef,
+            mockDependencyData
+        );
+
+        const diagnostic = vulnerability.getDiagnostic();
+        expect(diagnostic.message).to.include('rhtpa trusted-content recommendation:');
+        expect(diagnostic.message).to.not.include('pip.conf');
     });
 });


### PR DESCRIPTION
## Summary

- Read recommendations from `ProviderReport.recommendations` map instead of deprecated `DependencyReport.recommendation` field
- Each recommendation source (`trusted-content`, `trusted-libraries`, `hardened-images`) shows its own diagnostic message and Quick Fix action
- Trusted registry instructions only appear for `trusted-libraries` source
- Falls back to deprecated field when provider-level recommendations are absent (backward compat)
- Bump `@trustify-da/trustify-da-api-model` to `^2.0.8` and `@trustify-da/trustify-da-javascript-client` to `^0.3.0-ea.b68592e`
- Fix fragile image PURL parsing — replace `split(':')` with robust `parseImageRefFromPurl()` that handles registry ports and sha256 digests ([TC-4751](https://redhat.atlassian.net/browse/TC-4751))
- Fix `hasProviderRecommendations` scoping — move flag and artifact processing inside the provider loop so each provider is handled independently ([TC-4752](https://redhat.atlassian.net/browse/TC-4752))
- Replace custom PURL parser with existing `packageurl-js` library for spec-compliant parsing ([TC-4764](https://redhat.atlassian.net/browse/TC-4764))

Implements [TC-4695](https://redhat.atlassian.net/browse/TC-4695)

## Test plan

- [x] Single recommendation source produces diagnostic with correct source label
- [x] Multiple recommendation sources produce separate messages for same dependency
- [x] Recommendation-only dependency shows Information severity
- [x] Code action uses correct ref per source type
- [x] Fallback to deprecated field works when provider-level recommendations absent
- [x] Image recommendation reads from provider level
- [x] Trusted registry instructions only for trusted-libraries source
- [x] Manual testing with Python (pyproject.toml), Maven (pom.xml), Docker (Dockerfile) manifests
- [x] Image PURL parsing handles registry-qualified refs with port colons
- [x] Image PURL parsing handles sha256 digest refs
- [x] Multi-provider scoping: deprecated fallback used only for providers without recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4751]: https://redhat.atlassian.net/browse/TC-4751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4752]: https://redhat.atlassian.net/browse/TC-4752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4764]: https://redhat.atlassian.net/browse/TC-4764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ