### PR TITLE
chore: update changelog for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 1.0.0 (June 11th 2026)
 
 ### Enhancements
 


### PR DESCRIPTION
## Summary
- Updates the `## Unreleased` section in CHANGELOG.md to `## 1.0.0 (June 11th 2026)` so the prep-release workflow can find the release notes entry.

## Test plan
- [ ] Verify the prep-release workflow succeeds when triggered with `major`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Rename the 'Unreleased' changelog section to '1.0.0 (June 11th 2026)' to document the v1.0.0 release entry.