### PR TITLE
ci: use conventional commit format for release PRs

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           git add package.json
           git add package-lock.json
-          git commit -m "[release] ${{ steps.bump.outputs.version }}"
+          git commit -m "chore(release): ${{ steps.bump.outputs.version }}"
 
       - name: Push changes
         run: |
@@ -98,7 +98,7 @@ jobs:
           gh label create "${{ steps.bump.outputs.version }}" --force
           gh pr create \
             --base main \
-            --title "[release] ${{ steps.bump.outputs.version }}" \
+            --title "chore(release): ${{ steps.bump.outputs.version }}" \
             --body "$PR_BODY" \
             --head release/${{ steps.bump.outputs.version }} \
             --label "release" --label "${{ steps.bump.outputs.version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
   release:
     permissions: write-all
     runs-on: ubuntu-latest
-    if: "github.repository_owner == 'fabric8-analytics' && startsWith(github.event.head_commit.message, 'chore(release):')"
+    if: "github.repository_owner == 'fabric8-analytics' && contains(github.event.head_commit.message, 'chore(release):')"
     name: Create & publish a release
     environment: production
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
   release:
     permissions: write-all
     runs-on: ubuntu-latest
-    if: "github.repository_owner == 'fabric8-analytics' && startsWith(github.event.head_commit.message, '[release]')"
+    if: "github.repository_owner == 'fabric8-analytics' && startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Create & publish a release
     environment: production
 


### PR DESCRIPTION
## Summary
- Changes the release PR commit message and title from `[release] vX.Y.Z` to `chore(release): vX.Y.Z` to pass the conventional commits PR check
- Updates the release workflow trigger to match the new prefix

## Test plan
- [ ] Verify the next `prep-release` workflow creates a PR with a valid conventional commit title
- [ ] Verify the release workflow still triggers when the release PR is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adopt conventional-commit-style messages and titles for automated release pull requests and align the release workflow trigger with the new prefix.

CI:
- Update prep-release workflow to use `chore(release): vX.Y.Z` for commits and PR titles to satisfy conventional commit checks.
- Adjust release workflow condition to trigger on commits starting with the new `chore(release):` prefix.