### PR TITLE
feat: add unknown severity handling across analysis paths

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -72,6 +72,7 @@ test/
 - **Coverage**: nyc 17.0.0
 - **Test naming**: `"should [expected behavior]"`
 - **Mock pattern**: Mock classes defined within test suites
+- **Mock data typing**: Use `Partial<T>` with the real type instead of `Record<string, number>` or similar loose types for mock data, so typos in field names are caught at compile time
 - **Test scripts**: `npm run test-compile && node ./out/test/runTest.js`
 
 ## Commit Messages

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
-        "@trustify-da/trustify-da-api-model": "^2.0.8",
-        "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.b68592e",
+        "@trustify-da/trustify-da-api-model": "^2.0.9",
+        "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.4227d87",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "cli-table3": "^0.6.5",
@@ -888,9 +888,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@trustify-da/trustify-da-api-model": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-api-model/-/trustify-da-api-model-2.0.8.tgz",
-      "integrity": "sha512-i4wVuNzWg8ASPOKpeiuuMD9SJaYDlqWCDApknMRuskP9QBSMnAORtbzoFXBNoMXWPVYGI8SrSpfF3J7fAPvzIw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-api-model/-/trustify-da-api-model-2.0.9.tgz",
+      "integrity": "sha512-mBVl97HkEfGBtLZSJMLySS6toK4Se+nfBi1g8iVHwH/A+wikU/KzM3HAbTW7f4FLfhx5saoZi+Asf0chng7TPQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@trustify-da/trustify-da-javascript-client": {

--- a/package.json
+++ b/package.json
@@ -559,8 +559,8 @@
   },
   "dependencies": {
     "@redhat-developer/vscode-redhat-telemetry": "^0.8.0",
-    "@trustify-da/trustify-da-api-model": "^2.0.8",
-    "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.b68592e",
+    "@trustify-da/trustify-da-api-model": "^2.0.9",
+    "@trustify-da/trustify-da-javascript-client": "^0.3.0-ea.4227d87",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "^1.0.11",
     "cli-table3": "^0.6.5",

--- a/src/dependencyAnalysis/analysis.ts
+++ b/src/dependencyAnalysis/analysis.ts
@@ -52,6 +52,7 @@ export interface ResponseMetrics {
         high: number,
         medium: number,
         low: number,
+        unknown: number,
         remediations: number,
         recommendations: number,
       }
@@ -126,8 +127,9 @@ class AnalysisResponse {
                   transitive: sourceData.summary.transitive ?? 0,
                   critical: sourceData.summary.critical ?? 0,
                   high: sourceData.summary.high ?? 0,
-                  medium: sourceData.summary.dependencies ?? 0,
+                  medium: sourceData.summary.medium ?? 0,
                   low: sourceData.summary.low ?? 0,
+                  unknown: sourceData.summary.unknown ?? 0,
                   recommendations: sourceData.summary.recommendations ?? 0,
                   remediations: sourceData.summary.remediations ?? 0,
                   total: sourceData.summary.total ?? 0,

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -166,6 +166,8 @@ class AnalysisResponse {
       highestSeverity = 'MEDIUM';
     } else if (isDefined(summary, 'low') && summary.low > 0) {
       highestSeverity = 'LOW';
+    } else if (isDefined(summary, 'unknown') && summary.unknown > 0) {
+      highestSeverity = 'UNKNOWN';
     }
 
     return highestSeverity;

--- a/src/rhda.ts
+++ b/src/rhda.ts
@@ -161,6 +161,7 @@ function metricsFromReport(report: string): ResponseMetrics | undefined {
             high: source.summary.high ?? 0,
             medium: source.summary.medium ?? 0,
             low: source.summary.low ?? 0,
+            unknown: source.summary.unknown ?? 0,
             remediations: source.summary.remediations ?? 0,
             recommendations: source.summary.recommendations ?? 0,
           };

--- a/test/imageAnalysis/analysis.test.ts
+++ b/test/imageAnalysis/analysis.test.ts
@@ -11,6 +11,7 @@ import { executeImageAnalysis } from '../../src/imageAnalysis/analysis';
 import { Uri } from 'vscode';
 import { IImage } from '../../src/imageAnalysis/collector';
 import { type IOptions } from '../../src/imageAnalysis';
+import { SourceSummary } from '@trustify-da/trustify-da-api-model/model/v5/SourceSummary';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -19,7 +20,7 @@ chai.use(sinonChai);
  * Creates a mock IExhortAnalysisReport with a single provider/source
  * using the given SourceSummary fields.
  */
-function createMockReport(imageRef: string, summary: Record<string, number>) {
+function createMockReport(imageRef: string, summary: Partial<SourceSummary>) {
   return {
     [imageRef]: {
       providers: {

--- a/test/imageAnalysis/analysis.test.ts
+++ b/test/imageAnalysis/analysis.test.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable @typescript-eslint/naming-convention */
+'use strict';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+
+import * as exhortServices from '../../src/exhortServices';
+import { executeImageAnalysis } from '../../src/imageAnalysis/analysis';
+import { Uri } from 'vscode';
+import { IImage } from '../../src/imageAnalysis/collector';
+import { type IOptions } from '../../src/imageAnalysis';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+/**
+ * Creates a mock IExhortAnalysisReport with a single provider/source
+ * using the given SourceSummary fields.
+ */
+function createMockReport(imageRef: string, summary: Record<string, number>) {
+  return {
+    [imageRef]: {
+      providers: {
+        'test-provider': {
+          status: { ok: true },
+          sources: {
+            'test-source': {
+              summary: {
+                total: 0,
+                direct: 0,
+                transitive: 0,
+                dependencies: 0,
+                critical: 0,
+                high: 0,
+                medium: 0,
+                low: 0,
+                unknown: 0,
+                remediations: 0,
+                recommendations: 0,
+                ...summary,
+              },
+              dependencies: [],
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+suite('Image Analysis - getHighestSeverity', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  const mockUri = Uri.file('/mock/path');
+  const mockOptions = {} as IOptions;
+  const mockImages: IImage[] = [
+    {
+      name: { value: 'test-image:latest', position: { line: 0, column: 0 } },
+      line: 'FROM test-image:latest',
+      platform: undefined,
+    },
+  ];
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  /// Verifies that getHighestSeverity returns 'UNKNOWN' when only unknown-severity vulnerabilities exist.
+  test('should return UNKNOWN when only unknown severity vulnerabilities exist', async () => {
+    // Given a report where only unknown > 0
+    const mockReport = createMockReport('test-image:latest', { unknown: 3 });
+    sandbox.stub(exhortServices, 'imageAnalysisService').resolves(mockReport as any);
+
+    // When executing image analysis
+    const response = await executeImageAnalysis(mockUri, mockImages, mockOptions);
+
+    // Then the highest severity should be UNKNOWN
+    const imageDataArray = response.images.get('test-image:latest');
+    expect(imageDataArray).to.not.be.undefined;
+    expect(imageDataArray!).to.have.lengthOf(1);
+    expect(imageDataArray![0].highestVulnerabilitySeverity).to.equal('UNKNOWN');
+  });
+
+  /// Verifies that getHighestSeverity returns 'LOW' when both low and unknown vulnerabilities exist (LOW outranks UNKNOWN).
+  test('should return LOW when both low and unknown vulnerabilities exist', async () => {
+    // Given a report where both low and unknown > 0
+    const mockReport = createMockReport('test-image:latest', { low: 1, unknown: 2 });
+    sandbox.stub(exhortServices, 'imageAnalysisService').resolves(mockReport as any);
+
+    // When executing image analysis
+    const response = await executeImageAnalysis(mockUri, mockImages, mockOptions);
+
+    // Then the highest severity should be LOW (outranks UNKNOWN)
+    const imageDataArray = response.images.get('test-image:latest');
+    expect(imageDataArray).to.not.be.undefined;
+    expect(imageDataArray![0].highestVulnerabilitySeverity).to.equal('LOW');
+  });
+
+  /// Verifies that getHighestSeverity returns 'NONE' when no severity counts are present.
+  test('should return NONE when no vulnerabilities exist', async () => {
+    // Given a report where all severity counts are 0
+    const mockReport = createMockReport('test-image:latest', {});
+    sandbox.stub(exhortServices, 'imageAnalysisService').resolves(mockReport as any);
+
+    // When executing image analysis
+    const response = await executeImageAnalysis(mockUri, mockImages, mockOptions);
+
+    // Then the highest severity should be NONE
+    const imageDataArray = response.images.get('test-image:latest');
+    expect(imageDataArray).to.not.be.undefined;
+    expect(imageDataArray![0].highestVulnerabilitySeverity).to.equal('NONE');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `unknown` severity field to `ResponseMetrics` interface and map it in both component analysis (`analysis.ts`) and stack analysis (`rhda.ts`) code paths
- Update image analysis `getHighestSeverity()` cascade to handle `unknown`, ranked below LOW (CRITICAL > HIGH > MEDIUM > LOW > UNKNOWN)
- Fix pre-existing bug: `medium` severity was incorrectly mapped from `sourceData.summary.dependencies` instead of `sourceData.summary.medium`
- Bump `@trustify-da/trustify-da-api-model` to 2.0.9 and `@trustify-da/trustify-da-javascript-client` to 0.3.0-ea.4227d87 for the updated `SourceSummary` model

Implements [TC-4727](https://redhat.atlassian.net/browse/TC-4727)

## Test plan

- [x] Existing tests pass (288 passing, 3 pre-existing failures unrelated to this change)
- [x] New test: `getHighestSeverity` returns `UNKNOWN` when only unknown > 0
- [x] New test: `getHighestSeverity` returns `LOW` when both low and unknown > 0 (LOW outranks UNKNOWN)
- [x] New test: `getHighestSeverity` returns `NONE` when no severities present
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4727]: https://redhat.atlassian.net/browse/TC-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Handle unknown vulnerability severity across dependency and image analysis paths and update supporting models and tests.

New Features:
- Add support for an unknown severity field in analysis response metrics and image analysis highest-severity calculation.

Bug Fixes:
- Correct the mapping of medium severity counts from the source summary in dependency analysis.

Enhancements:
- Update metrics extraction for dependency and stack analysis to include unknown severity counts.
- Upgrade Trustify API model and JavaScript client dependencies to consume the updated SourceSummary model.

Tests:
- Add image analysis tests covering UNKNOWN, LOW vs UNKNOWN precedence, and NONE highest-severity outcomes.