### PR TITLE
feat: display hardened image recommendations and fix recommendation toggle

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -229,6 +229,7 @@ class Config {
     process.env['VSCEXT_TRUSTIFY_DA_DOCKER_PATH'] = this.exhortDockerPath;
     process.env['VSCEXT_TRUSTIFY_DA_PODMAN_PATH'] = this.exhortPodmanPath;
     process.env['VSCEXT_TRUSTIFY_DA_IMAGE_PLATFORM'] = this.exhortImagePlatform;
+    process.env['VSCEXT_TRUSTIFY_DA_RECOMMENDATIONS_ENABLED'] = this.recommendationsEnabled ? 'true' : 'false';
   }
 
   /**

--- a/src/dependencyAnalysis/diagnostics.ts
+++ b/src/dependencyAnalysis/diagnostics.ts
@@ -95,9 +95,14 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<DependencyData> {
   private createCodeAction(dependency: Dependency, loc: string, ref: string, context: IPositionedContext | undefined, sourceId: string, vulnerabilityDiagnostic: Diagnostic, recommendationSourceId: string = '') {
     const switchToVersion = ref.split('@')[1];
     const versionReplacementString = context ? context.value.replace(VERSION_PLACEHOLDER, switchToVersion) : switchToVersion;
-    const title = recommendationSourceId
-      ? `Switch to version ${switchToVersion} (${recommendationSourceId})`
-      : `Switch to version ${switchToVersion} for ${sourceId}`;
+    let title: string;
+    if (recommendationSourceId === 'hardened') {
+      title = `Switch to Red Hat Hardened version ${switchToVersion} for ${sourceId}`;
+    } else if (recommendationSourceId) {
+      title = `Switch to version ${switchToVersion} (${recommendationSourceId})`;
+    } else {
+      title = `Switch to version ${switchToVersion} for ${sourceId}`;
+    }
     const codeAction = generateSwitchToRecommendedVersionAction(title, ref, versionReplacementString, vulnerabilityDiagnostic, this.diagnosticFilePath, dependency.version);
     registerCodeAction(this.diagnosticFilePath, loc, codeAction);
   }
@@ -139,7 +144,8 @@ async function performDiagnostics(tokenProvider: TokenProvider, diagnosticFilePa
       'TRUSTIFY_DA_POETRY_PATH': globalConfig.exhortPoetryPath,
       'TRUSTIFY_DA_UV_PATH': globalConfig.exhortUvPath,
       'TRUSTIFY_DA_CARGO_PATH': globalConfig.exhortCargoPath,
-      'TRUSTIFY_DA_LICENSE_CHECK': globalConfig.licenseCheckEnabled.toString()
+      'TRUSTIFY_DA_LICENSE_CHECK': globalConfig.licenseCheckEnabled.toString(),
+      'TRUSTIFY_DA_RECOMMENDATIONS_ENABLED': globalConfig.recommendationsEnabled ? 'true' : 'false',
     };
 
     const dependencies = provider.collect(contents);

--- a/src/exhortServices.ts
+++ b/src/exhortServices.ts
@@ -38,6 +38,7 @@ function buildBaseOptions(): Options {
     'TRUSTIFY_DA_UV_PATH': globalConfig.exhortUvPath,
     'TRUSTIFY_DA_CARGO_PATH': globalConfig.exhortCargoPath,
     'TRUSTIFY_DA_PROXY_URL': globalConfig.exhortProxyUrl,
+    'TRUSTIFY_DA_RECOMMENDATIONS_ENABLED': globalConfig.recommendationsEnabled ? 'true' : 'false',
   };
 }
 

--- a/src/imageAnalysis/diagnostics.ts
+++ b/src/imageAnalysis/diagnostics.ts
@@ -81,7 +81,9 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
     const sourceLabel = recommendationSourceId
       ? `${sourceId} (${recommendationSourceId})`
       : sourceId;
-    const title = `${sourceLabel}: Switch to Red Hat UBI ${imageRef} for enhanced security and enterprise-grade stability`;
+    const title = recommendationSourceId === 'hardened'
+      ? `${sourceLabel}: Switch to Red Hat Hardened Image ${imageRef} for enhanced security`
+      : `${sourceLabel}: Switch to Red Hat UBI ${imageRef} for enhanced security and enterprise-grade stability`;
     const codeAction = generateRedirectToRecommendedVersionAction(title, imageRef, vulnerabilityDiagnostic, this.diagnosticFilePath);
     registerCodeAction(this.diagnosticFilePath, loc, codeAction);
   }
@@ -108,6 +110,7 @@ async function performDiagnostics(tokenProvider: TokenProvider, diagnosticFilePa
       'TRUSTIFY_DA_DOCKER_PATH': globalConfig.exhortDockerPath,
       'TRUSTIFY_DA_PODMAN_PATH': globalConfig.exhortPodmanPath,
       'TRUSTIFY_DA_IMAGE_PLATFORM': globalConfig.exhortImagePlatform,
+      'TRUSTIFY_DA_RECOMMENDATIONS_ENABLED': globalConfig.recommendationsEnabled ? 'true' : 'false',
     };
 
     const images = provider.collect(contents);

--- a/src/vulnerability.ts
+++ b/src/vulnerability.ts
@@ -70,7 +70,12 @@ Highest severity: ${artifactData.highestVulnerabilitySeverity}`;
    */
   private generateRecommendation(artifactData: DependencyData | ImageData): string {
     if (artifactData.recommendationSourceId) {
-      let base = `${artifactData.sourceId} ${artifactData.recommendationSourceId} recommendation:\n${artifactData.recommendationRef}`;
+      let base: string;
+      if (artifactData.recommendationSourceId === 'hardened') {
+        base = `${artifactData.sourceId} recommendation:\nA Red Hat Hardened Image is available: ${artifactData.recommendationRef}`;
+      } else {
+        base = `${artifactData.sourceId} ${artifactData.recommendationSourceId} recommendation:\n${artifactData.recommendationRef}`;
+      }
 
       if (artifactData.recommendationSourceId === 'trusted-libraries' && 'packageManager' in artifactData && artifactData.packageManager && artifactData.recommendationRef) {
         const instructions = getTrustedRegistryInstructions(artifactData.packageManager as pythonPackageManager);

--- a/test/codeActionHandler.test.ts
+++ b/test/codeActionHandler.test.ts
@@ -356,9 +356,28 @@ suite('Code Action Handler tests', () => {
             Uri.file('mock/path/Dockerfile')
         );
 
-        expect(codeAction.title).to.equal(title);
-        expect(codeAction.kind).to.deep.equal(CodeActionKind.QuickFix);
-        expect(codeAction.command!.arguments![0]).to.equal('ubi9/openjdk-11-hardened');
+        expect(codeAction).to.deep.equal(
+            {
+                'command': {
+                    'command': 'mockTrackRecommendationAcceptanceCommand',
+                    'title': 'Track recommendation acceptance',
+                    'arguments': [
+                        'ubi9/openjdk-11-hardened',
+                        'Dockerfile'
+                    ]
+                },
+                'diagnostics': [
+                    {
+                        'message': 'another mock message',
+                        'range': new Range(321, 321, 654, 654),
+                        'severity': 3,
+                        'source': 'mockSource'
+                    }
+                ],
+                'kind': { 'value': 'quickfix' },
+                'title': title
+            }
+        );
     });
 
     /**

--- a/test/codeActionHandler.test.ts
+++ b/test/codeActionHandler.test.ts
@@ -343,6 +343,25 @@ suite('Code Action Handler tests', () => {
     });
 
     /**
+     * Verifies that code action for hardened image recommendation uses distinct title.
+     */
+    test('should generate redirect code action for hardened image recommendation', async () => {
+        config.globalConfig.trackRecommendationAcceptanceCommand = 'mockTrackRecommendationAcceptanceCommand';
+
+        const title = 'rhtpa (hardened): Switch to Red Hat Hardened Image ubi9/openjdk-11-hardened for enhanced security';
+        const codeAction: CodeAction = codeActionHandler.generateRedirectToRecommendedVersionAction(
+            title,
+            'ubi9/openjdk-11-hardened',
+            mockDiagnostic1[0],
+            Uri.file('mock/path/Dockerfile')
+        );
+
+        expect(codeAction.title).to.equal(title);
+        expect(codeAction.kind).to.deep.equal(CodeActionKind.QuickFix);
+        expect(codeAction.command!.arguments![0]).to.equal('ubi9/openjdk-11-hardened');
+    });
+
+    /**
      * Verifies that code action uses the correct recommendation ref per source type
      * when recommendationSourceId is set on the DependencyData.
      */

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -148,6 +148,38 @@ suite('Config module', () => {
     expect(process.env['VSCEXT_TRUSTIFY_DA_DOCKER_PATH']).to.equal('docker');
     expect(process.env['VSCEXT_TRUSTIFY_DA_PODMAN_PATH']).to.equal('podman');
     expect(process.env['VSCEXT_TRUSTIFY_DA_IMAGE_PLATFORM']).to.equal('');
+    expect(process.env['VSCEXT_TRUSTIFY_DA_RECOMMENDATIONS_ENABLED']).to.equal('true');
+  });
+
+  /**
+   * Verifies that TRUSTIFY_DA_RECOMMENDATIONS_ENABLED is set to 'false'
+   * when recommendations.enabled is false.
+   */
+  test('should pass TRUSTIFY_DA_RECOMMENDATIONS_ENABLED=false when recommendations.enabled is false', async () => {
+    // Given recommendations are disabled
+    const rhdaConfig = vscode.workspace.getConfiguration('redHatDependencyAnalytics');
+    await rhdaConfig.update('recommendations.enabled', false, vscode.ConfigurationTarget.Global);
+
+    sandbox.stub(redhatTelemetry, 'getTelemetryId').resolves(mockId);
+
+    globalConfig.linkToSecretStorage({
+      secrets: {
+        onDidChange: sandbox.stub(),
+        store: () => sandbox.stub() as any,
+        get: async () => '',
+        delete: () => sandbox.stub() as any
+      }
+    });
+
+    // When authorizing
+    globalConfig.loadData();
+    await globalConfig.authorizeRHDA(context);
+
+    // Then the env var should be 'false'
+    expect(process.env['VSCEXT_TRUSTIFY_DA_RECOMMENDATIONS_ENABLED']).to.equal('false');
+
+    // Cleanup
+    await rhdaConfig.update('recommendations.enabled', undefined, vscode.ConfigurationTarget.Global);
   });
 }).beforeEach(() => {
   globalConfig.loadData();

--- a/test/vulnerability.test.ts
+++ b/test/vulnerability.test.ts
@@ -521,6 +521,49 @@ suite('Vulnerability tests', () => {
     });
 
     /**
+     * Verifies that hardened image recommendations produce a distinct diagnostic
+     * message with "A Red Hat Hardened Image is available" text.
+     */
+    test('should return diagnostic with hardened image recommendation message', async () => {
+        config.globalConfig.recommendationsEnabled = true;
+
+        const mockImageData: MockImageData[] = [
+            new MockImageData('rhtpa', [], 'ubi9/openjdk-11-hardened', 'NONE', 'hardened')
+        ];
+        const vulnerability = new Vulnerability(
+            mockRange,
+            mockImageRef,
+            mockImageData
+        );
+
+        const diagnostic = vulnerability.getDiagnostic();
+        expect(diagnostic.message).to.include('rhtpa recommendation:');
+        expect(diagnostic.message).to.include('A Red Hat Hardened Image is available: ubi9/openjdk-11-hardened');
+        expect(diagnostic.message).to.not.include('hardened recommendation:');
+        expect(diagnostic.severity).to.eql(DiagnosticSeverity.Information);
+    });
+
+    /**
+     * Verifies that hardened image recommendations are suppressed when
+     * recommendations.enabled is false.
+     */
+    test('should suppress hardened image recommendations when recommendations are disabled', async () => {
+        config.globalConfig.recommendationsEnabled = false;
+
+        const mockImageData: MockImageData[] = [
+            new MockImageData('rhtpa', [], 'ubi9/openjdk-11-hardened', 'NONE', 'hardened')
+        ];
+        const vulnerability = new Vulnerability(
+            mockRange,
+            mockImageRef,
+            mockImageData
+        );
+
+        const diagnostic = vulnerability.getDiagnostic();
+        expect(diagnostic.message).to.not.include('A Red Hat Hardened Image is available');
+    });
+
+    /**
      * Verifies that trusted registry instructions are NOT included for
      * the trusted-content recommendation source even when packageManager is set.
      */


### PR DESCRIPTION
## Summary
- Pass `TRUSTIFY_DA_RECOMMENDATIONS_ENABLED` to the JS client across all analysis paths (config, dependency diagnostics, image diagnostics, exhort services) so the backend respects the `recommendations.enabled` setting
- Add distinct diagnostic messages and code action titles for `hardened` recommendation source, differentiating them from UBI recommendations
- Include sourceId in hardened dependency code action titles for consistency with other recommendation types

## Test plan
- [x] Test: config passes `TRUSTIFY_DA_RECOMMENDATIONS_ENABLED=false` when `recommendations.enabled` is false
- [x] Test: hardened image recommendation produces distinct diagnostic message
- [x] Test: code action generates redirect action for hardened image recommendations
- [x] Test: hardened image recommendations are suppressed when recommendations are disabled
- [x] Lint passes (`npm run lint`)

Jira-Issue: TC-4810

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Propagate the recommendations-enabled setting to all analysis backends and refine hardened image recommendation messaging and code actions.

New Features:
- Surface distinct diagnostics and quick fixes for hardened image recommendations in dependency and image analysis.

Bug Fixes:
- Ensure recommendations are suppressed across diagnostics when the recommendations.enabled setting is disabled.
- Align code action titles and diagnostic messages for hardened recommendations with other recommendation types while including source identifiers.

Tests:
- Add unit coverage for hardened image diagnostics, code actions, and the TRUSTIFY_DA_RECOMMENDATIONS_ENABLED environment propagation.