### PR TITLE
feat: add quick-fix action to replace Dockerfile image with hardened recommendation

### DIFF
--- a/src/codeActionHandler.ts
+++ b/src/codeActionHandler.ts
@@ -88,14 +88,15 @@ function generateFullStackAnalysisAction(): CodeAction {
 /**
  * Generates a code action to switch to the recommended version.
  * @param title - The title of the code action.
- * @param dependency - The dependency (package and version) provided by exhort.
+ * @param packageName - The package name for telemetry tracking.
+ * @param version - The recommended version for telemetry tracking.
  * @param versionReplacementString - The version replacement string.
  * @param diagnostic - The diagnostic information.
  * @param uri - The URI of the file.
  * @param replacementRange - Optional range to use for the replacement instead of diagnostic range to be used rather than deriving from the diagnostic
  * @returns A CodeAction object for switching to the recommended version.
  */
-function generateSwitchToRecommendedVersionAction(title: string, dependency: string, versionReplacementString: string, diagnostic: Diagnostic, uri: Uri, replacementRange?: IPositionedString): CodeAction {
+function generateSwitchToRecommendedVersionAction(title: string, packageName: string, version: string | undefined, versionReplacementString: string, diagnostic: Diagnostic, uri: Uri, replacementRange?: IPositionedString): CodeAction {
   const codeAction: CodeAction = {
     title: title,
     diagnostics: [diagnostic],
@@ -111,7 +112,7 @@ function generateSwitchToRecommendedVersionAction(title: string, dependency: str
   codeAction.command = {
     title: 'Track recommendation acceptance',
     command: globalConfig.trackRecommendationAcceptanceCommand,
-    arguments: [dependency, path.basename(uri.fsPath)],
+    arguments: [packageName, version, path.basename(uri.fsPath)],
   };
 
   return codeAction;
@@ -120,13 +121,15 @@ function generateSwitchToRecommendedVersionAction(title: string, dependency: str
 /**
  * Generates a code action to replace the Dockerfile image with a hardened recommendation.
  * @param title - The title of the code action.
- * @param imageRef - The recommended hardened image reference.
+ * @param imageRef - The recommended hardened image reference (for the WorkspaceEdit replacement).
+ * @param packageName - The image name without version, for telemetry tracking.
+ * @param version - The image version (tag or digest), for telemetry tracking.
  * @param diagnostic - The diagnostic information covering the image name range.
  * @param uri - The URI of the Dockerfile.
  * @param replacementRange - The image name position and value, used to narrow the edit to just the image name portion of the FROM line.
  * @returns A CodeAction object that replaces the image reference and fires the tracking command.
  */
-function generateReplaceImageAction(title: string, imageRef: string, diagnostic: Diagnostic, uri: Uri, replacementRange: IPositionedString): CodeAction {
+function generateReplaceImageAction(title: string, imageRef: string, packageName: string, version: string | undefined, diagnostic: Diagnostic, uri: Uri, replacementRange: IPositionedString): CodeAction {
   const codeAction: CodeAction = {
     title: title,
     diagnostics: [diagnostic],
@@ -142,7 +145,7 @@ function generateReplaceImageAction(title: string, imageRef: string, diagnostic:
   codeAction.command = {
     title: 'Track recommendation acceptance',
     command: globalConfig.trackRecommendationAcceptanceCommand,
-    arguments: [imageRef, path.basename(uri.fsPath)],
+    arguments: [packageName, version, path.basename(uri.fsPath)],
   };
 
   return codeAction;

--- a/src/codeActionHandler.ts
+++ b/src/codeActionHandler.ts
@@ -118,19 +118,26 @@ function generateSwitchToRecommendedVersionAction(title: string, dependency: str
 }
 
 /**
- * Generates a code action to redirect to the recommended version catalog.
+ * Generates a code action to replace the Dockerfile image with a hardened recommendation.
  * @param title - The title of the code action.
- * @param imageRef - The image reference provided by exhort.
- * @param diagnostic - The diagnostic information.
- * @param uri - The URI of the file.
- * @returns A CodeAction object for redirecting to the recommended version catalog.
+ * @param imageRef - The recommended hardened image reference.
+ * @param diagnostic - The diagnostic information covering the image name range.
+ * @param uri - The URI of the Dockerfile.
+ * @param replacementRange - The image name position and value, used to narrow the edit to just the image name portion of the FROM line.
+ * @returns A CodeAction object that replaces the image reference and fires the tracking command.
  */
-function generateRedirectToRecommendedVersionAction(title: string, imageRef: string, diagnostic: Diagnostic, uri: Uri): CodeAction {
+function generateReplaceImageAction(title: string, imageRef: string, diagnostic: Diagnostic, uri: Uri, replacementRange: IPositionedString): CodeAction {
   const codeAction: CodeAction = {
     title: title,
     diagnostics: [diagnostic],
     kind: CodeActionKind.QuickFix,
+    edit: new WorkspaceEdit()
   };
+
+  codeAction.edit!.replace(uri, new Range(
+    new Position(replacementRange.position.line - 1, replacementRange.position.column),
+    new Position(replacementRange.position.line - 1, replacementRange.position.column + replacementRange.value.length)
+  ), imageRef);
 
   codeAction.command = {
     title: 'Track recommendation acceptance',
@@ -163,4 +170,4 @@ function generateUpdateManifestLicenseAction(fileLicense: string, diagnostic: Di
   return codeAction;
 }
 
-export { getCodeActionsMap, clearCodeActionsMap, registerCodeAction, generateSwitchToRecommendedVersionAction, generateRedirectToRecommendedVersionAction, getDiagnosticsCodeActions, generateUpdateManifestLicenseAction };
+export { getCodeActionsMap, clearCodeActionsMap, registerCodeAction, generateSwitchToRecommendedVersionAction, generateReplaceImageAction, getDiagnosticsCodeActions, generateUpdateManifestLicenseAction };

--- a/src/dependencyAnalysis/diagnostics.ts
+++ b/src/dependencyAnalysis/diagnostics.ts
@@ -93,6 +93,7 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<DependencyData> {
    * @private
    */
   private createCodeAction(dependency: Dependency, loc: string, ref: string, context: IPositionedContext | undefined, sourceId: string, vulnerabilityDiagnostic: Diagnostic, recommendationSourceId: string = '') {
+    const packageName = ref.split('@')[0];
     const switchToVersion = ref.split('@')[1];
     const versionReplacementString = context ? context.value.replace(VERSION_PLACEHOLDER, switchToVersion) : switchToVersion;
     let title: string;
@@ -103,7 +104,7 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<DependencyData> {
     } else {
       title = `Switch to version ${switchToVersion} for ${sourceId}`;
     }
-    const codeAction = generateSwitchToRecommendedVersionAction(title, ref, versionReplacementString, vulnerabilityDiagnostic, this.diagnosticFilePath, dependency.version);
+    const codeAction = generateSwitchToRecommendedVersionAction(title, packageName, switchToVersion, versionReplacementString, vulnerabilityDiagnostic, this.diagnosticFilePath, dependency.version);
     registerCodeAction(this.diagnosticFilePath, loc, codeAction);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -306,8 +306,8 @@ async function enableExtensionFeatures(context: vscode.ExtensionContext, tokenPr
 
   const disposableTrackRecommendationAcceptance = vscode.commands.registerCommand(
     commands.TRACK_RECOMMENDATION_ACCEPTANCE_COMMAND,
-    (dependency, fileName) => {
-      record(context, TelemetryActions.componentAnalysisRecommendationAccepted, { manifest: fileName, fileName: fileName, package: dependency.split('@')[0], version: dependency.split('@')[1] });
+    (packageName, version, fileName) => {
+      record(context, TelemetryActions.componentAnalysisRecommendationAccepted, { manifest: fileName, fileName: fileName, package: packageName, version: version });
 
       if (fileName === 'Dockerfile' || fileName === 'Containerfile') {
         redirectToRedHatCatalog();

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -46,6 +46,9 @@ function parseImageRefFromPurl(purl: string): string {
     // repository_url already contains the full image path (e.g., quay.io/hummingbird/go),
     // so use it directly. Only fall back to namespace/name when repository_url is absent.
     const fullName = repositoryUrl || [parsed.namespace, parsed.name].filter(Boolean).join('/');
+    if (!fullName) {
+      return '';
+    }
     if (!parsed.version) {
       return fullName;
     }

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -35,27 +35,40 @@ interface IArtifact {
 }
 
 /**
+ * Structured result from parsing an image PURL.
+ */
+interface ParsedImageRef {
+  /** Full image reference string (e.g., `quay.io/hummingbird/go:1.25`). */
+  ref: string;
+  /** Image name without version (e.g., `quay.io/hummingbird/go`). */
+  packageName: string;
+  /** Version portion (tag or digest), or undefined if absent. */
+  version: string | undefined;
+}
+
+/**
  * Reconstructs a full image reference from a PURL string, including registry and tag.
  * @param purl - A Package URL string (e.g., `pkg:oci/go@1.25?repository_url=quay.io/hummingbird/go`).
- * @returns The full image reference (e.g., `quay.io/hummingbird/go:1.25`), or empty string if invalid.
+ * @returns A structured image reference with separate name and version, or null if invalid.
  */
-function parseImageRefFromPurl(purl: string): string {
+function parseImageRefFromPurl(purl: string): ParsedImageRef | null {
   try {
     const parsed = PackageURL.fromString(purl);
     const repositoryUrl = parsed.qualifiers?.repository_url;
     // repository_url already contains the full image path (e.g., quay.io/hummingbird/go),
     // so use it directly. Only fall back to namespace/name when repository_url is absent.
-    const fullName = repositoryUrl || [parsed.namespace, parsed.name].filter(Boolean).join('/');
-    if (!fullName) {
-      return '';
+    const packageName = repositoryUrl || [parsed.namespace, parsed.name].filter(Boolean).join('/');
+    if (!packageName) {
+      return null;
     }
-    if (!parsed.version) {
-      return fullName;
+    const version = parsed.version || undefined;
+    if (!version) {
+      return { ref: packageName, packageName, version };
     }
-    const separator = parsed.version.startsWith('sha256:') ? '@' : ':';
-    return `${fullName}${separator}${parsed.version}`;
+    const separator = version.startsWith('sha256:') ? '@' : ':';
+    return { ref: `${packageName}${separator}${version}`, packageName, version };
   } catch {
-    return '';
+    return null;
   }
 }
 
@@ -65,7 +78,9 @@ class ImageData {
     public issues: Issue[],
     public recommendationRef: string,
     public highestVulnerabilitySeverity: string,
-    public recommendationSourceId: string = ''
+    public recommendationSourceId: string = '',
+    public recommendationPackage: string = '',
+    public recommendationVersion: string | undefined = undefined,
   ) { }
 }
 
@@ -101,16 +116,17 @@ class AnalysisResponse {
                 if (recSourceData.dependencies) {
                   recSourceData.dependencies.forEach(recReport => {
                     if (recReport.recommendation) {
-                      const recommendationRef = parseImageRefFromPurl(recReport.recommendation);
-                      const dedupeKey = `${recommendationRef}|${recSourceName}`;
-                      if (recommendationRef && !seenRecommendations.has(dedupeKey)) {
-                        seenRecommendations.add(dedupeKey);
+                      const parsed = parseImageRefFromPurl(recReport.recommendation);
+                      if (parsed && !seenRecommendations.has(`${parsed.ref}|${recSourceName}`)) {
+                        seenRecommendations.add(`${parsed.ref}|${recSourceName}`);
                         const sd = new ImageData(
                           providerName,
                           [],
-                          recommendationRef,
+                          parsed.ref,
                           'NONE',
-                          recSourceName
+                          recSourceName,
+                          parsed.packageName,
+                          parsed.version,
                         );
                         const dataArray = this.images.get(imageRef) || [];
                         dataArray.push(sd);
@@ -123,11 +139,15 @@ class AnalysisResponse {
             }
 
             artifacts.forEach(artifact => {
+              const recommendation = hasProviderRecommendations ? null : this.getRecommendation(artifact.dependencies);
               const sd = new ImageData(
                 artifact.id,
                 artifact.dependencies?.flatMap(dependency => dependency.issues || []) || [],
-                hasProviderRecommendations ? '' : this.getRecommendation(artifact.dependencies),
+                recommendation?.ref ?? '',
                 this.getHighestSeverity(artifact.summary),
+                '',
+                recommendation?.packageName ?? '',
+                recommendation?.version,
               );
 
               const dataArray = this.images.get(imageRef) || [];
@@ -192,12 +212,11 @@ class AnalysisResponse {
    * @returns The recommendation reference or an empty string.
    * @private
    */
-  private getRecommendation(dependencies: DependencyReport[] | undefined): string {
-    let recommendation = '';
-    if (dependencies && dependencies.length > 0) {
-      recommendation = isDefined(dependencies[0], 'recommendation') ? parseImageRefFromPurl(dependencies[0].recommendation) : '';
+  private getRecommendation(dependencies: DependencyReport[] | undefined): ParsedImageRef | null {
+    if (dependencies && dependencies.length > 0 && isDefined(dependencies[0], 'recommendation')) {
+      return parseImageRefFromPurl(dependencies[0].recommendation);
     }
-    return recommendation;
+    return null;
   }
 }
 

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -46,7 +46,11 @@ function parseImageRefFromPurl(purl: string): string {
     // repository_url already contains the full image path (e.g., quay.io/hummingbird/go),
     // so use it directly. Only fall back to namespace/name when repository_url is absent.
     const fullName = repositoryUrl || [parsed.namespace, parsed.name].filter(Boolean).join('/');
-    return parsed.version ? `${fullName}:${parsed.version}` : fullName;
+    if (!parsed.version) {
+      return fullName;
+    }
+    const separator = parsed.version.startsWith('sha256:') ? '@' : ':';
+    return `${fullName}${separator}${parsed.version}`;
   } catch {
     return '';
   }

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -35,15 +35,18 @@ interface IArtifact {
 }
 
 /**
- * Extracts the namespace/name image reference from a PURL string using the
- * spec-compliant `packageurl-js` library.
- * @param purl - A Package URL string (e.g., `pkg:docker/nginx@1.25`).
- * @returns The namespace/name portion (e.g., `nginx`), or empty string if invalid.
+ * Reconstructs a full image reference from a PURL string, including registry and tag.
+ * @param purl - A Package URL string (e.g., `pkg:oci/go@1.25?repository_url=quay.io/hummingbird/go`).
+ * @returns The full image reference (e.g., `quay.io/hummingbird/go:1.25`), or empty string if invalid.
  */
 function parseImageRefFromPurl(purl: string): string {
   try {
     const parsed = PackageURL.fromString(purl);
-    return [parsed.namespace, parsed.name].filter(Boolean).join('/');
+    const repositoryUrl = parsed.qualifiers?.repository_url;
+    // repository_url already contains the full image path (e.g., quay.io/hummingbird/go),
+    // so use it directly. Only fall back to namespace/name when repository_url is absent.
+    const fullName = repositoryUrl || [parsed.namespace, parsed.name].filter(Boolean).join('/');
+    return parsed.version ? `${fullName}:${parsed.version}` : fullName;
   } catch {
     return '';
   }
@@ -86,12 +89,15 @@ class AnalysisResponse {
 
             if (isDefined(providerData, 'recommendations')) {
               hasProviderRecommendations = true;
+              const seenRecommendations = new Set<string>();
               Object.entries(providerData.recommendations).map(([recSourceName, recSourceData]) => {
                 if (recSourceData.dependencies) {
                   recSourceData.dependencies.forEach(recReport => {
                     if (recReport.recommendation) {
                       const recommendationRef = parseImageRefFromPurl(recReport.recommendation);
-                      if (recommendationRef) {
+                      const dedupeKey = `${recommendationRef}|${recSourceName}`;
+                      if (recommendationRef && !seenRecommendations.has(dedupeKey)) {
+                        seenRecommendations.add(dedupeKey);
                         const sd = new ImageData(
                           providerName,
                           [],

--- a/src/imageAnalysis/collector.ts
+++ b/src/imageAnalysis/collector.ts
@@ -15,6 +15,7 @@ export interface IImage {
   name: IPositionedString;
   line: string;
   platform: string | undefined;
+  rawToken?: IPositionedString;
 }
 
 /**
@@ -22,6 +23,7 @@ export interface IImage {
  */
 export class Image implements IImage {
   public platform: string | undefined;
+  public rawToken?: IPositionedString;
 
   constructor(
     public name: IPositionedString,

--- a/src/imageAnalysis/collector.ts
+++ b/src/imageAnalysis/collector.ts
@@ -102,5 +102,7 @@ export function getRange(img: IImage): Range {
   const pos: IPosition = img.name.position;
   const length = img.line.length;
 
-  return new Range(new Position(pos.line - 1, pos.column), new Position(pos.line - 1, pos.column + length));
+  // Diagnostic range covers the entire FROM line (column 0 to line end).
+  // image.name.position.column tracks the image-name offset for replacement edits.
+  return new Range(new Position(pos.line - 1, 0), new Position(pos.line - 1, length));
 }

--- a/src/imageAnalysis/diagnostics.ts
+++ b/src/imageAnalysis/diagnostics.ts
@@ -60,7 +60,7 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
             if (!registeredRecommendations.has(dedupeKey)) {
               registeredRecommendations.add(dedupeKey);
               const replacementRange = image.rawToken ?? image.name;
-              this.createCodeAction(loc, id.recommendationRef, id.sourceId, vulnerabilityDiagnostic, replacementRange, id.recommendationSourceId);
+              this.createCodeAction(loc, id.recommendationRef, id.sourceId, vulnerabilityDiagnostic, replacementRange, id.recommendationSourceId, id.recommendationPackage, id.recommendationVersion);
             }
           }
 
@@ -85,14 +85,14 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
    * @param recommendationSourceId - Optional recommendation source identifier.
    * @private
    */
-  private createCodeAction(loc: string, imageRef: string, sourceId: string, vulnerabilityDiagnostic: Diagnostic, imageName: IPositionedString, recommendationSourceId: string = '') {
+  private createCodeAction(loc: string, imageRef: string, sourceId: string, vulnerabilityDiagnostic: Diagnostic, imageName: IPositionedString, recommendationSourceId: string = '', packageName: string = '', version: string | undefined = undefined) {
     const sourceLabel = recommendationSourceId
       ? `${sourceId} (${recommendationSourceId})`
       : sourceId;
     const title = recommendationSourceId === 'hardened'
       ? `${sourceLabel}: Switch to Red Hat Hardened Image ${imageRef} for enhanced security`
       : `${sourceLabel}: Switch to Red Hat UBI ${imageRef} for enhanced security and enterprise-grade stability`;
-    const replaceAction = generateReplaceImageAction(title, imageRef, vulnerabilityDiagnostic, this.diagnosticFilePath, imageName);
+    const replaceAction = generateReplaceImageAction(title, imageRef, packageName, version, vulnerabilityDiagnostic, this.diagnosticFilePath, imageName);
     registerCodeAction(this.diagnosticFilePath, loc, replaceAction);
   }
 }

--- a/src/imageAnalysis/diagnostics.ts
+++ b/src/imageAnalysis/diagnostics.ts
@@ -59,7 +59,8 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
             const dedupeKey = `${id.recommendationRef}|${id.recommendationSourceId}`;
             if (!registeredRecommendations.has(dedupeKey)) {
               registeredRecommendations.add(dedupeKey);
-              this.createCodeAction(loc, id.recommendationRef, id.sourceId, vulnerabilityDiagnostic, image.name, id.recommendationSourceId);
+              const replacementRange = image.rawToken ?? image.name;
+              this.createCodeAction(loc, id.recommendationRef, id.sourceId, vulnerabilityDiagnostic, replacementRange, id.recommendationSourceId);
             }
           }
 

--- a/src/imageAnalysis/diagnostics.ts
+++ b/src/imageAnalysis/diagnostics.ts
@@ -7,7 +7,8 @@
 import { buildLogErrorMessage, buildNotificationErrorMessage } from '../utils';
 import { IImageProvider, ImageMap, getRange } from '../imageAnalysis/collector';
 import { AbstractDiagnosticsPipeline } from '../diagnosticsPipeline';
-import { clearCodeActionsMap, registerCodeAction, generateRedirectToRecommendedVersionAction } from '../codeActionHandler';
+import { clearCodeActionsMap, registerCodeAction, generateReplaceImageAction } from '../codeActionHandler';
+import { IPositionedString } from '../positionTypes';
 import { executeImageAnalysis, ImageData } from './analysis';
 import { Vulnerability } from '../vulnerability';
 import { Diagnostic, DiagnosticSeverity, Uri } from 'vscode';
@@ -51,10 +52,15 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
         this.diagnostics.push(vulnerabilityDiagnostic);
 
         const loc = vulnerabilityDiagnostic.range.start.line + '|' + vulnerabilityDiagnostic.range.start.character;
+        const registeredRecommendations = new Set<string>();
 
         imageData.forEach(id => {
           if (id.recommendationRef && globalConfig.recommendationsEnabled) {
-            this.createCodeAction(loc, id.recommendationRef, id.sourceId, vulnerabilityDiagnostic, id.recommendationSourceId);
+            const dedupeKey = `${id.recommendationRef}|${id.recommendationSourceId}`;
+            if (!registeredRecommendations.has(dedupeKey)) {
+              registeredRecommendations.add(dedupeKey);
+              this.createCodeAction(loc, id.recommendationRef, id.sourceId, vulnerabilityDiagnostic, image.name, id.recommendationSourceId);
+            }
           }
 
           for (const vuln of id.issues) {
@@ -71,21 +77,22 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
   /**
    * Creates a code action.
    * @param loc - Location of code action effect.
-   * @param imageRef - The reference name of the image.
+   * @param imageRef - The reference name of the recommended image.
    * @param sourceId - Source ID.
    * @param vulnerabilityDiagnostic - Vulnerability diagnostic object.
+   * @param imageName - The original image name position and value, used to narrow the replacement range.
    * @param recommendationSourceId - Optional recommendation source identifier.
    * @private
    */
-  private createCodeAction(loc: string, imageRef: string, sourceId: string, vulnerabilityDiagnostic: Diagnostic, recommendationSourceId: string = '') {
+  private createCodeAction(loc: string, imageRef: string, sourceId: string, vulnerabilityDiagnostic: Diagnostic, imageName: IPositionedString, recommendationSourceId: string = '') {
     const sourceLabel = recommendationSourceId
       ? `${sourceId} (${recommendationSourceId})`
       : sourceId;
     const title = recommendationSourceId === 'hardened'
       ? `${sourceLabel}: Switch to Red Hat Hardened Image ${imageRef} for enhanced security`
       : `${sourceLabel}: Switch to Red Hat UBI ${imageRef} for enhanced security and enterprise-grade stability`;
-    const codeAction = generateRedirectToRecommendedVersionAction(title, imageRef, vulnerabilityDiagnostic, this.diagnosticFilePath);
-    registerCodeAction(this.diagnosticFilePath, loc, codeAction);
+    const replaceAction = generateReplaceImageAction(title, imageRef, vulnerabilityDiagnostic, this.diagnosticFilePath, imageName);
+    registerCodeAction(this.diagnosticFilePath, loc, replaceAction);
   }
 }
 

--- a/src/providers/docker.ts
+++ b/src/providers/docker.ts
@@ -75,6 +75,11 @@ export class ImageProvider implements IImageProvider {
     const imageMatch = line.match(this.FROM_REGEX);
     if (imageMatch) {
       let imageData = imageMatch[1];
+
+      // Extract the raw token before ARG expansion for accurate replacement range
+      let rawImageToken = imageData.replace(this.PLATFORM_REGEX, '');
+      rawImageToken = rawImageToken.replace(this.AS_REGEX, '').trim();
+
       imageData = this.replaceArgsInString(imageData);
       imageData = imageData.replace(this.PLATFORM_REGEX, '');
 
@@ -91,7 +96,12 @@ export class ImageProvider implements IImageProvider {
       }
 
       const col = line.indexOf(imageData);
-      const image = new Image({ value: imageData, position: { line: index + 1, column: col !== -1 ? col : 0 } }, line);
+      const rawCol = line.indexOf(rawImageToken);
+      const image = new Image({ value: imageData, position: { line: index + 1, column: col !== -1 ? col : rawCol } }, line);
+
+      if (rawImageToken !== imageData) {
+        image.rawToken = { value: rawImageToken, position: { line: index + 1, column: rawCol } };
+      }
 
       const platformMatch = line.match(this.PLATFORM_REGEX);
       if (platformMatch) {

--- a/src/providers/docker.ts
+++ b/src/providers/docker.ts
@@ -97,10 +97,10 @@ export class ImageProvider implements IImageProvider {
 
       const col = line.indexOf(imageData);
       const rawCol = line.indexOf(rawImageToken);
-      const image = new Image({ value: imageData, position: { line: index + 1, column: col !== -1 ? col : rawCol } }, line);
+      const image = new Image({ value: imageData, position: { line: index + 1, column: col !== -1 ? col : Math.max(0, rawCol) } }, line);
 
       if (rawImageToken !== imageData) {
-        image.rawToken = { value: rawImageToken, position: { line: index + 1, column: rawCol } };
+        image.rawToken = { value: rawImageToken, position: { line: index + 1, column: Math.max(0, rawCol) } };
       }
 
       const platformMatch = line.match(this.PLATFORM_REGEX);

--- a/src/providers/docker.ts
+++ b/src/providers/docker.ts
@@ -90,7 +90,8 @@ export class ImageProvider implements IImageProvider {
         return;
       }
 
-      const image = new Image({ value: imageData, position: { line: index + 1, column: 0 } }, line);
+      const col = line.indexOf(imageData);
+      const image = new Image({ value: imageData, position: { line: index + 1, column: col !== -1 ? col : 0 } }, line);
 
       const platformMatch = line.match(this.PLATFORM_REGEX);
       if (platformMatch) {

--- a/test/codeActionHandler.test.ts
+++ b/test/codeActionHandler.test.ts
@@ -14,6 +14,7 @@ import { DependencyData } from '../src/dependencyAnalysis/analysis';
 import { Dependency, DependencyMap } from '../src/dependencyAnalysis/collector';
 import { Vulnerability } from '../src/vulnerability';
 import { CodeAction, CodeActionKind, Diagnostic, DiagnosticSeverity, Position, Range, Uri, WorkspaceEdit } from 'vscode';
+import { IPositionedString } from '../src/positionTypes';
 
 suite('Code Action Handler tests', () => {
 
@@ -223,60 +224,125 @@ suite('Code Action Handler tests', () => {
         );
     });
 
-    test('should return a redirect to recommended version code action for Dockerfile', async () => {
+    /**
+     * Verifies that generateReplaceImageAction creates a CodeAction with a WorkspaceEdit
+     * that replaces only the image name range (not the full diagnostic range).
+     */
+    test('should return a replace image code action with WorkspaceEdit scoped to image name for Dockerfile', async () => {
+        // Given a configured tracking command, a diagnostic, and an image name range
         config.globalConfig.trackRecommendationAcceptanceCommand = 'mockTrackRecommendationAcceptanceCommand';
+        const uri = Uri.file('mock/path/Dockerfile');
+        const title = 'rhtpa (hardened): Switch to Red Hat Hardened Image ubi9/openjdk-11-hardened:latest for enhanced security';
+        const imageName: IPositionedString = { value: 'golang:1.21', position: { line: 322, column: 5 } };
 
-        const codeAction: CodeAction = codeActionHandler.generateRedirectToRecommendedVersionAction('mockTitle', 'mockImage@mockTag', mockDiagnostic1[0], Uri.file('mock/path/Dockerfile'));
+        // When generating a replace image action
+        const expectedRange = new Range(
+            new Position(321, 5),
+            new Position(321, 5 + 'golang:1.21'.length)
+        );
+        const edit = new WorkspaceEdit();
+        edit.replace(uri, expectedRange, 'ubi9/openjdk-11-hardened:latest');
+        const codeAction: CodeAction = codeActionHandler.generateReplaceImageAction(
+            title,
+            'ubi9/openjdk-11-hardened:latest',
+            mockDiagnostic1[0],
+            uri,
+            imageName
+        );
+
+        // Then the code action should have a WorkspaceEdit scoped to the image name
         expect(codeAction).to.deep.equal(
             {
                 'command': {
                     'command': 'mockTrackRecommendationAcceptanceCommand',
                     'title': 'Track recommendation acceptance',
                     'arguments': [
-                        'mockImage@mockTag',
+                        'ubi9/openjdk-11-hardened:latest',
                         'Dockerfile'
                     ]
                 },
                 'diagnostics': [
                     {
                         'message': 'another mock message',
-                        'range': new Range(321, 321, 654, 654),
+                        'range': mockDiagnostic1[0].range,
                         'severity': 3,
                         'source': 'mockSource'
                     }
                 ],
+                'edit': edit,
                 'kind': { 'value': 'quickfix' },
-                'title': 'mockTitle'
+                'title': title
             }
         );
     });
 
-    test('should return a redirect to recommended version code action for Containerfile', async () => {
-        config.globalConfig.trackRecommendationAcceptanceCommand = 'mockTrackRecommendationAcceptanceCommand';
+    /**
+     * Verifies that generateReplaceImageAction attaches the tracking command to the code action.
+     */
+    test('should attach tracking command to replace image code action', async () => {
+        // Given a configured tracking command
+        config.globalConfig.trackRecommendationAcceptanceCommand = 'mockTrackCommand';
+        const uri = Uri.file('mock/path/Containerfile');
+        const imageName: IPositionedString = { value: 'node:18', position: { line: 322, column: 5 } };
 
-        const codeAction: CodeAction = codeActionHandler.generateRedirectToRecommendedVersionAction('mockTitle', 'mockImage@mockTag', mockDiagnostic1[0], Uri.file('mock/path/Containerfile'));
-        expect(codeAction).to.deep.equal(
-            {
-                'command': {
-                    'command': 'mockTrackRecommendationAcceptanceCommand',
-                    'title': 'Track recommendation acceptance',
-                    'arguments': [
-                        'mockImage@mockTag',
-                        'Containerfile'
-                    ]
-                },
-                'diagnostics': [
-                    {
-                        'message': 'another mock message',
-                        'range': new Range(321, 321, 654, 654),
-                        'severity': 3,
-                        'source': 'mockSource'
-                    }
-                ],
-                'kind': { 'value': 'quickfix' },
-                'title': 'mockTitle'
-            }
+        // When generating a replace image action
+        const codeAction: CodeAction = codeActionHandler.generateReplaceImageAction(
+            'rhtpa: Switch to Red Hat UBI ubi9/openjdk-17:latest for enhanced security and enterprise-grade stability',
+            'ubi9/openjdk-17:latest',
+            mockDiagnostic1[0],
+            uri,
+            imageName
         );
+
+        // Then the tracking command should be attached with the image ref and file name
+        expect(codeAction.command).to.deep.equal({
+            'command': 'mockTrackCommand',
+            'title': 'Track recommendation acceptance',
+            'arguments': [
+                'ubi9/openjdk-17:latest',
+                'Containerfile'
+            ]
+        });
+    });
+
+    /**
+     * Verifies that multiple hardened recommendations produce multiple replace actions
+     * registered at the same location.
+     */
+    test('should register multiple replace actions for multiple hardened recommendations at the same location', () => {
+        // Given multiple hardened image recommendations for the same location
+        config.globalConfig.trackRecommendationAcceptanceCommand = 'mockTrackCommand';
+        const uri = Uri.file('mock/path/Dockerfile');
+        const loc = '10|5';
+        const imageName: IPositionedString = { value: 'golang:1.21', position: { line: 11, column: 5 } };
+
+        const replaceAction1 = codeActionHandler.generateReplaceImageAction(
+            'rhtpa (hardened): Switch to Red Hat Hardened Image ubi9/openjdk-11-hardened:latest for enhanced security',
+            'ubi9/openjdk-11-hardened:latest',
+            mockDiagnostic1[0],
+            uri,
+            imageName
+        );
+        const replaceAction2 = codeActionHandler.generateReplaceImageAction(
+            'rhtpa (hardened): Switch to Red Hat Hardened Image ubi9/openjdk-17-hardened:latest for enhanced security',
+            'ubi9/openjdk-17-hardened:latest',
+            mockDiagnostic1[0],
+            uri,
+            imageName
+        );
+
+        // When registering both actions at the same location
+        codeActionHandler.registerCodeAction(uri, loc, replaceAction1);
+        codeActionHandler.registerCodeAction(uri, loc, replaceAction2);
+
+        // Then both actions should be available at that location
+        const actions = codeActionHandler.getCodeActionsMap().get(uri.toString())?.get(loc);
+        expect(actions).to.have.lengthOf(2);
+        expect(actions![0].title).to.contain('ubi9/openjdk-11-hardened:latest');
+        expect(actions![1].title).to.contain('ubi9/openjdk-17-hardened:latest');
+        expect(actions![0].edit).to.not.be.undefined;
+        expect(actions![1].edit).to.not.be.undefined;
+        codeActionHandler.clearCodeActionsMap(uri);
     });
 
     /**
@@ -340,44 +406,6 @@ suite('Code Action Handler tests', () => {
         // Then it should select remediationRef, not recommendationRef
         expect(actionRef).to.equal(remediationRef);
         expect(actionRef).to.not.equal('');
-    });
-
-    /**
-     * Verifies that code action for hardened image recommendation uses distinct title.
-     */
-    test('should generate redirect code action for hardened image recommendation', async () => {
-        config.globalConfig.trackRecommendationAcceptanceCommand = 'mockTrackRecommendationAcceptanceCommand';
-
-        const title = 'rhtpa (hardened): Switch to Red Hat Hardened Image ubi9/openjdk-11-hardened for enhanced security';
-        const codeAction: CodeAction = codeActionHandler.generateRedirectToRecommendedVersionAction(
-            title,
-            'ubi9/openjdk-11-hardened',
-            mockDiagnostic1[0],
-            Uri.file('mock/path/Dockerfile')
-        );
-
-        expect(codeAction).to.deep.equal(
-            {
-                'command': {
-                    'command': 'mockTrackRecommendationAcceptanceCommand',
-                    'title': 'Track recommendation acceptance',
-                    'arguments': [
-                        'ubi9/openjdk-11-hardened',
-                        'Dockerfile'
-                    ]
-                },
-                'diagnostics': [
-                    {
-                        'message': 'another mock message',
-                        'range': new Range(321, 321, 654, 654),
-                        'severity': 3,
-                        'source': 'mockSource'
-                    }
-                ],
-                'kind': { 'value': 'quickfix' },
-                'title': title
-            }
-        );
     });
 
     /**

--- a/test/codeActionHandler.test.ts
+++ b/test/codeActionHandler.test.ts
@@ -198,14 +198,15 @@ suite('Code Action Handler tests', () => {
         const edit = new WorkspaceEdit();
         const uri = Uri.file('mock/path/pom.xml');
         edit.replace(uri, mockDiagnostic1[0].range, 'mockVersionReplacementString');
-        const codeAction: CodeAction = codeActionHandler.generateSwitchToRecommendedVersionAction('mockTitle', 'mockPackage@mockversion', 'mockVersionReplacementString', mockDiagnostic1[0], uri);
+        const codeAction: CodeAction = codeActionHandler.generateSwitchToRecommendedVersionAction('mockTitle', 'mockPackage', 'mockversion', 'mockVersionReplacementString', mockDiagnostic1[0], uri);
         expect(codeAction).to.deep.equal(
             {
                 'command': {
                     'command': 'mockTrackRecommendationAcceptanceCommand',
                     'title': 'Track recommendation acceptance',
                     'arguments': [
-                        'mockPackage@mockversion',
+                        'mockPackage',
+                        'mockversion',
                         'pom.xml'
                     ]
                 },
@@ -245,6 +246,8 @@ suite('Code Action Handler tests', () => {
         const codeAction: CodeAction = codeActionHandler.generateReplaceImageAction(
             title,
             'ubi9/openjdk-11-hardened:latest',
+            'ubi9/openjdk-11-hardened',
+            'latest',
             mockDiagnostic1[0],
             uri,
             imageName
@@ -257,7 +260,8 @@ suite('Code Action Handler tests', () => {
                     'command': 'mockTrackRecommendationAcceptanceCommand',
                     'title': 'Track recommendation acceptance',
                     'arguments': [
-                        'ubi9/openjdk-11-hardened:latest',
+                        'ubi9/openjdk-11-hardened',
+                        'latest',
                         'Dockerfile'
                     ]
                 },
@@ -289,6 +293,8 @@ suite('Code Action Handler tests', () => {
         const codeAction: CodeAction = codeActionHandler.generateReplaceImageAction(
             'rhtpa: Switch to Red Hat UBI ubi9/openjdk-17:latest for enhanced security and enterprise-grade stability',
             'ubi9/openjdk-17:latest',
+            'ubi9/openjdk-17',
+            'latest',
             mockDiagnostic1[0],
             uri,
             imageName
@@ -299,7 +305,8 @@ suite('Code Action Handler tests', () => {
             'command': 'mockTrackCommand',
             'title': 'Track recommendation acceptance',
             'arguments': [
-                'ubi9/openjdk-17:latest',
+                'ubi9/openjdk-17',
+                'latest',
                 'Containerfile'
             ]
         });
@@ -319,6 +326,8 @@ suite('Code Action Handler tests', () => {
         const replaceAction1 = codeActionHandler.generateReplaceImageAction(
             'rhtpa (hardened): Switch to Red Hat Hardened Image ubi9/openjdk-11-hardened:latest for enhanced security',
             'ubi9/openjdk-11-hardened:latest',
+            'ubi9/openjdk-11-hardened',
+            'latest',
             mockDiagnostic1[0],
             uri,
             imageName
@@ -326,6 +335,8 @@ suite('Code Action Handler tests', () => {
         const replaceAction2 = codeActionHandler.generateReplaceImageAction(
             'rhtpa (hardened): Switch to Red Hat Hardened Image ubi9/openjdk-17-hardened:latest for enhanced security',
             'ubi9/openjdk-17-hardened:latest',
+            'ubi9/openjdk-17-hardened',
+            'latest',
             mockDiagnostic1[0],
             uri,
             imageName

--- a/test/imageAnalysis.test.ts
+++ b/test/imageAnalysis.test.ts
@@ -155,7 +155,7 @@ suite('AnalysisResponse provider scoping', () => {
             d => d.sourceId === 'providerA' && d.recommendationSourceId === 'trusted-content'
         );
         expect(providerARecommendation).to.not.be.undefined;
-        expect(providerARecommendation!.recommendationRef).to.equal('ubi9/nginx');
+        expect(providerARecommendation!.recommendationRef).to.equal('ubi9/nginx:1.26');
 
         // providerA's artifact should have empty recommendationRef (suppressed by provider recommendations)
         const providerAArtifact = imageDataList!.find(
@@ -169,6 +169,6 @@ suite('AnalysisResponse provider scoping', () => {
             d => d.sourceId === 'providerB(sourceB)' && d.recommendationSourceId === ''
         );
         expect(providerBArtifact).to.not.be.undefined;
-        expect(providerBArtifact!.recommendationRef).to.equal('nginx');
+        expect(providerBArtifact!.recommendationRef).to.equal('nginx:1.27');
     });
 });

--- a/test/imageAnalysis.test.ts
+++ b/test/imageAnalysis.test.ts
@@ -260,3 +260,48 @@ suite('AnalysisResponse provider scoping', () => {
         expect(providerBArtifact!.recommendationRef).to.equal('nginx:1.27');
     });
 });
+
+suite('AnalysisResponse empty fullName guard', () => {
+    /**
+     * Verifies that a malformed recommendation PURL does not produce a recommendation
+     * entry with a corrupt image reference.
+     */
+    test('should not create recommendation entry when recommendation PURL is invalid', () => {
+        // Given a recommendation with an unparseable PURL
+        const mockData = {
+            'docker.io/test:1.0': {
+                providers: {
+                    providerA: {
+                        status: { ok: true },
+                        sources: {
+                            sourceA: {
+                                summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0 },
+                                dependencies: [],
+                            },
+                        },
+                        recommendations: {
+                            'trusted-content': {
+                                dependencies: [{
+                                    ref: 'pkg:oci/test@1.0?repository_url=docker.io/test',
+                                    recommendation: 'not-a-valid-purl',
+                                }],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        // When constructing AnalysisResponse
+        const response = new AnalysisResponse(mockData as any, Uri.file('/mock/Dockerfile'));
+
+        // Then no trusted-content recommendation entry should exist (empty ref filtered out)
+        const imageDataList = response.images.get('docker.io/test:1.0');
+        expect(imageDataList).to.not.be.undefined;
+
+        const recommendation = imageDataList!.find(
+            d => d.recommendationSourceId === 'trusted-content'
+        );
+        expect(recommendation).to.be.undefined;
+    });
+});

--- a/test/imageAnalysis.test.ts
+++ b/test/imageAnalysis.test.ts
@@ -91,6 +91,94 @@ FROM stage1 AS runner
     });
 });
 
+suite('AnalysisResponse digest vs tag separator', () => {
+    /**
+     * Verifies that a digest version (sha256:...) produces an image reference using @ separator.
+     */
+    test('should use @ separator for digest version in recommendation', () => {
+        // Given a recommendation PURL with a sha256 digest version
+        const mockData = {
+            'docker.io/alpine:3.18': {
+                providers: {
+                    providerA: {
+                        status: { ok: true },
+                        sources: {
+                            sourceA: {
+                                summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0 },
+                                dependencies: [],
+                            },
+                        },
+                        recommendations: {
+                            'trusted-content': {
+                                dependencies: [{
+                                    ref: 'pkg:oci/alpine@3.18?repository_url=docker.io/library/alpine',
+                                    recommendation: 'pkg:oci/alpine@sha256%3Aabc123def456?repository_url=docker.io/library/alpine',
+                                }],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        // When constructing AnalysisResponse
+        const response = new AnalysisResponse(mockData as any, Uri.file('/mock/Dockerfile'));
+
+        // Then the recommendation should use @ separator for the digest
+        const imageDataList = response.images.get('docker.io/alpine:3.18');
+        expect(imageDataList).to.not.be.undefined;
+
+        const recommendation = imageDataList!.find(
+            d => d.recommendationSourceId === 'trusted-content'
+        );
+        expect(recommendation).to.not.be.undefined;
+        expect(recommendation!.recommendationRef).to.equal('docker.io/library/alpine@sha256:abc123def456');
+    });
+
+    /**
+     * Verifies that a tag version continues to produce an image reference using : separator.
+     */
+    test('should use : separator for tag version in recommendation', () => {
+        // Given a recommendation PURL with a regular tag version
+        const mockData = {
+            'docker.io/nginx:1.25': {
+                providers: {
+                    providerA: {
+                        status: { ok: true },
+                        sources: {
+                            sourceA: {
+                                summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0 },
+                                dependencies: [],
+                            },
+                        },
+                        recommendations: {
+                            'trusted-content': {
+                                dependencies: [{
+                                    ref: 'pkg:oci/nginx@1.25?repository_url=docker.io/library/nginx',
+                                    recommendation: 'pkg:oci/nginx@1.26?repository_url=docker.io/library/nginx',
+                                }],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        // When constructing AnalysisResponse
+        const response = new AnalysisResponse(mockData as any, Uri.file('/mock/Dockerfile'));
+
+        // Then the recommendation should use : separator for the tag
+        const imageDataList = response.images.get('docker.io/nginx:1.25');
+        expect(imageDataList).to.not.be.undefined;
+
+        const recommendation = imageDataList!.find(
+            d => d.recommendationSourceId === 'trusted-content'
+        );
+        expect(recommendation).to.not.be.undefined;
+        expect(recommendation!.recommendationRef).to.equal('docker.io/library/nginx:1.26');
+    });
+});
+
 suite('AnalysisResponse provider scoping', () => {
     /**
      * Verifies that hasProviderRecommendations is scoped per-provider, not per-image.

--- a/test/providers/docker.test.ts
+++ b/test/providers/docker.test.ts
@@ -196,15 +196,40 @@ FROM $ARG_IMAGE
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'python:3.9.5', position: { line: 4, column: 0 } },
+                name: { value: 'python:3.9.5', position: { line: 4, column: 28 } },
                 line: 'FROM --platform=linux/amd64 ${ARG_IMAGE}:${ARG_TAG} as stage1$ARG_FAKE',
-                platform: 'linux/amd64'
+                platform: 'linux/amd64',
+                rawToken: { value: '${ARG_IMAGE}:${ARG_TAG}', position: { line: 4, column: 28 } }
             },
             {
-                name: { value: 'python', position: { line: 5, column: 0 } },
+                name: { value: 'python', position: { line: 5, column: 5 } },
                 line: 'FROM $ARG_IMAGE',
+                rawToken: { value: '$ARG_IMAGE', position: { line: 5, column: 5 } }
             }
         ]);
+    });
+
+    /**
+     * Verifies that ARG-expanded FROM lines store rawToken for accurate quick-fix replacement.
+     */
+    test('tests ARG-expanded FROM lines store rawToken with original placeholder range', async () => {
+        // Given a Dockerfile with ARG placeholders in FROM lines
+        const deps = dependencyProvider.collect(`
+ARG BASE=nginx
+FROM \${BASE}:latest
+FROM --platform=linux/amd64 \${BASE}
+        `);
+
+        // Then ARG-expanded images should have rawToken with placeholder text and position
+        expect(deps.length).to.equal(2);
+        expect(deps[0].rawToken).to.deep.equal({ value: '${BASE}:latest', position: { line: 3, column: 5 } });
+        expect(deps[1].rawToken).to.deep.equal({ value: '${BASE}', position: { line: 4, column: 28 } });
+
+        // And non-ARG FROM lines should not have rawToken
+        const deps2 = dependencyProvider.collect(`
+FROM nginx:latest
+        `);
+        expect(deps2[0].rawToken).to.be.undefined;
     });
 
     test('tests file with image registries', async () => {

--- a/test/providers/docker.test.ts
+++ b/test/providers/docker.test.ts
@@ -26,19 +26,19 @@ FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1a
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'alpine', position: { line: 2, column: 0 } },
+                name: { value: 'alpine', position: { line: 2, column: 5 } },
                 line: 'FROM alpine'
             },
             {
-                name: { value: 'alpine:latest', position: { line: 3, column: 0 } },
+                name: { value: 'alpine:latest', position: { line: 3, column: 5 } },
                 line: 'FROM alpine:latest'
             },
             {
-                name: { value: 'alpine:1.2.3', position: { line: 4, column: 0 } },
+                name: { value: 'alpine:1.2.3', position: { line: 4, column: 5 } },
                 line: 'FROM alpine:1.2.3'
             },
             {
-                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 5, column: 0 } },
+                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 5, column: 5 } },
                 line: 'FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b'
             }
         ]);
@@ -56,19 +56,19 @@ FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1a
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'alpine', position: { line: 3, column: 0 } },
+                name: { value: 'alpine', position: { line: 3, column: 5 } },
                 line: 'FROM alpine'
             },
             {
-                name: { value: 'alpine:latest', position: { line: 5, column: 0 } },
+                name: { value: 'alpine:latest', position: { line: 5, column: 5 } },
                 line: 'FROM alpine:latest'
             },
             {
-                name: { value: 'alpine:1.2.3', position: { line: 6, column: 0 } },
+                name: { value: 'alpine:1.2.3', position: { line: 6, column: 5 } },
                 line: 'FROM alpine:1.2.3'
             },
             {
-                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 7, column: 0 } },
+                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 7, column: 5 } },
                 line: 'FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b'
             }
         ]);
@@ -91,19 +91,19 @@ FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1a
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'alpine', position: { line: 3, column: 0 } },
+                name: { value: 'alpine', position: { line: 3, column: 5 } },
                 line: 'FROM alpine'
             },
             {
-                name: { value: 'alpine:latest', position: { line: 6, column: 0 } },
+                name: { value: 'alpine:latest', position: { line: 6, column: 5 } },
                 line: 'FROM alpine:latest'
             },
             {
-                name: { value: 'alpine:1.2.3', position: { line: 7, column: 0 } },
+                name: { value: 'alpine:1.2.3', position: { line: 7, column: 5 } },
                 line: 'FROM alpine:1.2.3'
             },
             {
-                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 12, column: 0 } },
+                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 12, column: 5 } },
                 line: 'FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b'
             }
         ]);
@@ -118,22 +118,22 @@ FROM --platform=linux/amd64 alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeb
         `);
         expect(deps).is.eql([
             {
-                name: { value: 'alpine', position: { line: 2, column: 0 } },
+                name: { value: 'alpine', position: { line: 2, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine',
                 platform: 'linux/amd64'
             },
             {
-                name: { value: 'alpine:latest', position: { line: 3, column: 0 } },
+                name: { value: 'alpine:latest', position: { line: 3, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine:latest',
                 platform: 'linux/amd64'
             },
             {
-                name: { value: 'alpine:1.2.3', position: { line: 4, column: 0 } },
+                name: { value: 'alpine:1.2.3', position: { line: 4, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine:1.2.3',
                 platform: 'linux/amd64'
             },
             {
-                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 5, column: 0 } },
+                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 5, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b',
                 platform: 'linux/amd64'
             }
@@ -148,15 +148,15 @@ FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1a
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'alpine', position: { line: 2, column: 0 } },
+                name: { value: 'alpine', position: { line: 2, column: 5 } },
                 line: 'FROM alpine as stage1'
             },
             {
-                name: { value: 'alpine:latest', position: { line: 3, column: 0 } },
+                name: { value: 'alpine:latest', position: { line: 3, column: 5 } },
                 line: 'FROM alpine:latest As stage2'
             },
             {
-                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 4, column: 0 } },
+                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 4, column: 5 } },
                 line: 'FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b AS stage3'
             }
         ]);
@@ -170,17 +170,17 @@ FROM --platform=linux/amd64 alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeb
         `);
         expect(deps).is.eql([
             {
-                name: { value: 'alpine', position: { line: 2, column: 0 } },
+                name: { value: 'alpine', position: { line: 2, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine as stage1',
                 platform: 'linux/amd64'
             },
             {
-                name: { value: 'alpine:latest', position: { line: 3, column: 0 } },
+                name: { value: 'alpine:latest', position: { line: 3, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine:latest As stage2',
                 platform: 'linux/amd64'
             },
             {
-                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 4, column: 0 } },
+                name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 4, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b AS stage3',
                 platform: 'linux/amd64'
             }
@@ -214,11 +214,11 @@ FROM registry.access.redhat.com/ubi9/nodejs-20-minimal
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'docker.io/library/nginx:1.2.3', position: { line: 2, column: 0 } },
+                name: { value: 'docker.io/library/nginx:1.2.3', position: { line: 2, column: 5 } },
                 line: 'FROM docker.io/library/nginx:1.2.3'
             },
             {
-                name: { value: 'registry.access.redhat.com/ubi9/nodejs-20-minimal', position: { line: 3, column: 0 } },
+                name: { value: 'registry.access.redhat.com/ubi9/nodejs-20-minimal', position: { line: 3, column: 5 } },
                 line: 'FROM registry.access.redhat.com/ubi9/nodejs-20-minimal'
             }
         ]);
@@ -231,19 +231,19 @@ FROM alpine
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'alpine', position: { line: 3, column: 0 } },
+                name: { value: 'alpine', position: { line: 3, column: 5 } },
                 line: 'FROM alpine'
             }
         ]);
     });
 
     test('tests file with spaces before and after image and line', async () => {
-        const deps = dependencyProvider.collect(`      
+        const deps = dependencyProvider.collect(`
             FROM    alpine:latest      as stage1
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'alpine:latest', position: { line: 2, column: 0 } },
+                name: { value: 'alpine:latest', position: { line: 2, column: 20 } },
                 line: '            FROM    alpine:latest      as stage1'
             }
         ]);
@@ -261,7 +261,7 @@ COPY --from=builder /app /app
         expect(deps.length).to.equal(1);
         expect(deps).is.containSubset([
             {
-                name: { value: 'node:26-alpine', position: { line: 2, column: 0 } },
+                name: { value: 'node:26-alpine', position: { line: 2, column: 5 } },
                 line: 'FROM node:26-alpine AS base'
             }
         ]);
@@ -276,7 +276,7 @@ FROM BASE AS runner
         expect(deps.length).to.equal(1);
         expect(deps).is.containSubset([
             {
-                name: { value: 'alpine:latest', position: { line: 2, column: 0 } },
+                name: { value: 'alpine:latest', position: { line: 2, column: 5 } },
                 line: 'FROM alpine:latest AS Base'
             }
         ]);
@@ -291,12 +291,12 @@ FROM --platform=linux/arm64 alpine:3.19 AS runtime
         expect(deps.length).to.equal(2);
         expect(deps).is.eql([
             {
-                name: { value: 'node:20', position: { line: 2, column: 0 } },
+                name: { value: 'node:20', position: { line: 2, column: 28 } },
                 line: 'FROM --platform=linux/amd64 node:20 AS build',
                 platform: 'linux/amd64'
             },
             {
-                name: { value: 'alpine:3.19', position: { line: 4, column: 0 } },
+                name: { value: 'alpine:3.19', position: { line: 4, column: 28 } },
                 line: 'FROM --platform=linux/arm64 alpine:3.19 AS runtime',
                 platform: 'linux/arm64'
             }
@@ -328,7 +328,7 @@ CMD ["node", "index.js"]
         `);
         expect(deps).is.containSubset([
             {
-                name: { value: 'node:14', position: { line: 3, column: 0 } },
+                name: { value: 'node:14', position: { line: 3, column: 5 } },
                 line: 'FROM node:14'
             }
         ]);

--- a/test/providers/docker.test.ts
+++ b/test/providers/docker.test.ts
@@ -120,22 +120,26 @@ FROM --platform=linux/amd64 alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeb
             {
                 name: { value: 'alpine', position: { line: 2, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine',
-                platform: 'linux/amd64'
+                platform: 'linux/amd64',
+                rawToken: undefined
             },
             {
                 name: { value: 'alpine:latest', position: { line: 3, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine:latest',
-                platform: 'linux/amd64'
+                platform: 'linux/amd64',
+                rawToken: undefined
             },
             {
                 name: { value: 'alpine:1.2.3', position: { line: 4, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine:1.2.3',
-                platform: 'linux/amd64'
+                platform: 'linux/amd64',
+                rawToken: undefined
             },
             {
                 name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 5, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b',
-                platform: 'linux/amd64'
+                platform: 'linux/amd64',
+                rawToken: undefined
             }
         ]);
     });
@@ -172,17 +176,20 @@ FROM --platform=linux/amd64 alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeb
             {
                 name: { value: 'alpine', position: { line: 2, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine as stage1',
-                platform: 'linux/amd64'
+                platform: 'linux/amd64',
+                rawToken: undefined
             },
             {
                 name: { value: 'alpine:latest', position: { line: 3, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine:latest As stage2',
-                platform: 'linux/amd64'
+                platform: 'linux/amd64',
+                rawToken: undefined
             },
             {
                 name: { value: 'alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b', position: { line: 4, column: 28 } },
                 line: 'FROM --platform=linux/amd64 alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b AS stage3',
-                platform: 'linux/amd64'
+                platform: 'linux/amd64',
+                rawToken: undefined
             }
         ]);
     });
@@ -318,12 +325,14 @@ FROM --platform=linux/arm64 alpine:3.19 AS runtime
             {
                 name: { value: 'node:20', position: { line: 2, column: 28 } },
                 line: 'FROM --platform=linux/amd64 node:20 AS build',
-                platform: 'linux/amd64'
+                platform: 'linux/amd64',
+                rawToken: undefined
             },
             {
                 name: { value: 'alpine:3.19', position: { line: 4, column: 28 } },
                 line: 'FROM --platform=linux/arm64 alpine:3.19 AS runtime',
-                platform: 'linux/arm64'
+                platform: 'linux/arm64',
+                rawToken: undefined
             }
         ]);
     });

--- a/test/vulnerability.test.ts
+++ b/test/vulnerability.test.ts
@@ -38,7 +38,9 @@ suite('Vulnerability tests', () => {
             public issues: Issue[],
             public recommendationRef: string,
             public highestVulnerabilitySeverity: string,
-            public recommendationSourceId: string = ''
+            public recommendationSourceId: string = '',
+            public recommendationPackage: string = '',
+            public recommendationVersion: string | undefined = undefined,
         ) { }
     }
 


### PR DESCRIPTION
## Summary

- Replace the redirect-only image code action with a `WorkspaceEdit`-based quick-fix that replaces the FROM line image reference with the recommended hardened image
- Fix PURL parsing (`parseImageRefFromPurl`) to use `repository_url` directly and include version tag, producing correct full image references (e.g., `quay.io/hummingbird/go:1.25` instead of `go/go`)
- Fix Docker provider to calculate accurate column position for image names within FROM lines, and decouple diagnostic range from replacement range
- Deduplicate identical provider-level recommendations in both `AnalysisResponse` and code action registration
- Fix `parseImageRefFromPurl` to use `@` separator for digest versions (sha256:...) instead of `:`, preventing malformed references like `alpine:sha256:abc123`
- Preserve quick-fix for ARG-expanded FROM lines by extracting raw token range before variable expansion, so the replacement correctly targets the placeholder text
- Guard `parseImageRefFromPurl` against empty `fullName` producing malformed refs like `:1.25`

Implements [TC-4939](https://redhat.atlassian.net/browse/TC-4939)
Implements [TC-5044](https://redhat.atlassian.net/browse/TC-5044)
Implements [TC-5043](https://redhat.atlassian.net/browse/TC-5043)
Implements [TC-5042](https://redhat.atlassian.net/browse/TC-5042)

## Test plan

- [ ] Verify quick-fix appears on hover for Dockerfile FROM lines with hardened recommendations
- [ ] Verify selecting the quick-fix replaces only the image name (not FROM keyword or platform flags)
- [ ] Verify hover text shows correct full image reference without duplication
- [ ] Verify multiple distinct recommendations produce multiple quick-fix options
- [ ] Verify identical recommendations are deduplicated (single entry in hover and quick-fix)
- [ ] Verify quick-fix works correctly for FROM lines with ARG placeholders
- [ ] Verify tracking command fires after replacement
- [ ] Run `npm test` to confirm all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4939]: https://redhat.atlassian.net/browse/TC-4939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ