### PR TITLE
fix(imageAnalysis): use tag qualifier as version fallback for OCI PURLs

### DIFF
--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -61,7 +61,7 @@ function parseImageRefFromPurl(purl: string): ParsedImageRef | null {
     if (!packageName) {
       return null;
     }
-    const version = parsed.version || undefined;
+    const version = parsed.version || parsed.qualifiers?.tag || undefined;
     if (!version) {
       return { ref: packageName, packageName, version };
     }


### PR DESCRIPTION
## Summary

- Fall back to `parsed.qualifiers?.tag` when `parsed.version` is absent in `parseImageRefFromPurl`, so OCI PURLs where the tag is encoded in qualifiers (e.g., `pkg:oci/go?repository_url=quay.io/hummingbird/go&tag=1.25`) produce unique image references
- This fixes hardened image recommendations being deduplicated to a single quick-fix action instead of showing all variants (standard, builder, fips, fips-builder)

Implements [TC-5110](https://redhat.atlassian.net/browse/TC-5110)

## Test plan

- [ ] Verify with `FROM golang:1.25` that 4 quick-fix actions appear (go:1.25, go:1.25-builder, go:1.25-fips, go:1.25-fips-builder)
- [ ] Verify with a single-recommendation image that 1 quick-fix action appears
- [ ] Verify existing image analysis diagnostics are not affected

[TC-5110]: https://redhat.atlassian.net/browse/TC-5110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Ensure OCI images with tags encoded in PURL qualifiers produce unique image references, preventing hardened image recommendations from being incorrectly deduplicated.