### PR TITLE
feat: remove UBI branding from recommendation messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ Specify glob patterns for manifests to be ignored for background analysis e.g. `
     <br >Upon opening a Dockerfile, a vulnerability scan starts analyzing the images within the Dockerfile.
     After the analysis finishes, you can view any recommendations and remediation by clicking the _Quick Fix..._ menu from the highlighted image name.
 	Any recommendations for an alternative image does not replace the current image.
-	By clicking _Switch to..._, you go to Red Hat's Ecosystem Catalog for the recommended image.
 
 	<br >You must have the [`syft`](https://github.com/anchore/syft#installation) and [`skopeo`](https://www.redhat.com/en/topics/containers/what-is-skopeo) binaries installed on your workstation to use the Docker scanning feature.
 	You can specify a specific path to these binaries, and others by settings the following parameters:

--- a/README.md
+++ b/README.md
@@ -208,10 +208,10 @@ Specify glob patterns for manifests to be ignored for background analysis e.g. `
 - **Docker scanning**
     <br >Upon opening a Dockerfile, a vulnerability scan starts analyzing the images within the Dockerfile.
     After the analysis finishes, you can view any recommendations and remediation by clicking the _Quick Fix..._ menu from the highlighted image name.
-	Any recommendations for an alternative image does not replace the current image.
+	Any recommendations for an alternative image do not replace the current image.
 
 	<br >You must have the [`syft`](https://github.com/anchore/syft#installation) and [`skopeo`](https://www.redhat.com/en/topics/containers/what-is-skopeo) binaries installed on your workstation to use the Docker scanning feature.
-	You can specify a specific path to these binaries, and others by settings the following parameters:
+	You can specify a specific path to these binaries, and others by setting the following parameters:
 
 	* `syft.executable.path`: Specify the absolute path of `syft` executable
 	* `syft.config.path`: Specify the absolute path to the Syft configuration file

--- a/src/dependencyAnalysis/diagnostics.ts
+++ b/src/dependencyAnalysis/diagnostics.ts
@@ -97,9 +97,7 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<DependencyData> {
     const switchToVersion = ref.split('@')[1];
     const versionReplacementString = context ? context.value.replace(VERSION_PLACEHOLDER, switchToVersion) : switchToVersion;
     let title: string;
-    if (recommendationSourceId === 'hardened') {
-      title = `Switch to Red Hat Hardened version ${switchToVersion} for ${sourceId}`;
-    } else if (recommendationSourceId) {
+    if (recommendationSourceId) {
       title = `Switch to version ${switchToVersion} (${recommendationSourceId})`;
     } else {
       title = `Switch to version ${switchToVersion} for ${sourceId}`;

--- a/src/imageAnalysis/diagnostics.ts
+++ b/src/imageAnalysis/diagnostics.ts
@@ -89,11 +89,9 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
     const sourceLabel = recommendationSourceId
       ? `${sourceId} (${recommendationSourceId})`
       : sourceId;
-    const title = recommendationSourceId === 'hardened'
-      ? `${sourceLabel}: Switch to Red Hat Hardened Image ${imageRef} for enhanced security`
-      : `${sourceLabel}: Switch to Red Hat UBI ${imageRef} for enhanced security and enterprise-grade stability`;
-    const replaceAction = generateReplaceImageAction(title, imageRef, packageName, version, vulnerabilityDiagnostic, this.diagnosticFilePath, imageName);
-    registerCodeAction(this.diagnosticFilePath, loc, replaceAction);
+    const title = `${sourceLabel}: Switch to ${imageRef} for enhanced security`;
+    const codeAction = generateRedirectToRecommendedVersionAction(title, imageRef, vulnerabilityDiagnostic, this.diagnosticFilePath);
+    registerCodeAction(this.diagnosticFilePath, loc, codeAction);
   }
 }
 

--- a/src/imageAnalysis/diagnostics.ts
+++ b/src/imageAnalysis/diagnostics.ts
@@ -90,8 +90,8 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<ImageData> {
       ? `${sourceId} (${recommendationSourceId})`
       : sourceId;
     const title = `${sourceLabel}: Switch to ${imageRef} for enhanced security`;
-    const codeAction = generateRedirectToRecommendedVersionAction(title, imageRef, vulnerabilityDiagnostic, this.diagnosticFilePath);
-    registerCodeAction(this.diagnosticFilePath, loc, codeAction);
+    const replaceAction = generateReplaceImageAction(title, imageRef, packageName, version, vulnerabilityDiagnostic, this.diagnosticFilePath, imageName);
+    registerCodeAction(this.diagnosticFilePath, loc, replaceAction);
   }
 }
 

--- a/src/vulnerability.ts
+++ b/src/vulnerability.ts
@@ -70,12 +70,7 @@ Highest severity: ${artifactData.highestVulnerabilitySeverity}`;
    */
   private generateRecommendation(artifactData: DependencyData | ImageData): string {
     if (artifactData.recommendationSourceId) {
-      let base: string;
-      if (artifactData.recommendationSourceId === 'hardened') {
-        base = `${artifactData.sourceId} recommendation:\nRecommended image: ${artifactData.recommendationRef}`;
-      } else {
-        base = `${artifactData.sourceId} ${artifactData.recommendationSourceId} recommendation:\n${artifactData.recommendationRef}`;
-      }
+      let base = `${artifactData.sourceId} ${artifactData.recommendationSourceId} recommendation:\nRecommended: ${artifactData.recommendationRef}`;
 
       if (artifactData.recommendationSourceId === 'trusted-libraries' && 'packageManager' in artifactData && artifactData.packageManager && artifactData.recommendationRef) {
         const instructions = getTrustedRegistryInstructions(artifactData.packageManager as pythonPackageManager);

--- a/src/vulnerability.ts
+++ b/src/vulnerability.ts
@@ -72,7 +72,7 @@ Highest severity: ${artifactData.highestVulnerabilitySeverity}`;
     if (artifactData.recommendationSourceId) {
       let base: string;
       if (artifactData.recommendationSourceId === 'hardened') {
-        base = `${artifactData.sourceId} recommendation:\nA Red Hat Hardened Image is available: ${artifactData.recommendationRef}`;
+        base = `${artifactData.sourceId} recommendation:\nRecommended image: ${artifactData.recommendationRef}`;
       } else {
         base = `${artifactData.sourceId} ${artifactData.recommendationSourceId} recommendation:\n${artifactData.recommendationRef}`;
       }
@@ -88,7 +88,7 @@ Highest severity: ${artifactData.highestVulnerabilitySeverity}`;
 
     const base = `${artifactData.sourceId} vulnerability info:
 Known security vulnerabilities: ${artifactData.issues.length}
-Recommendation: ${artifactData.recommendationRef || 'No Red Hat recommendations'}`;
+Recommendation: ${artifactData.recommendationRef || 'No recommendations'}`;
 
     if ('packageManager' in artifactData && artifactData.packageManager && artifactData.recommendationRef) {
       const instructions = getTrustedRegistryInstructions(artifactData.packageManager as pythonPackageManager);

--- a/test/codeActionHandler.test.ts
+++ b/test/codeActionHandler.test.ts
@@ -420,6 +420,44 @@ suite('Code Action Handler tests', () => {
     });
 
     /**
+     * Verifies that code action for hardened image recommendation uses distinct title.
+     */
+    test('should generate redirect code action for hardened image recommendation', async () => {
+        config.globalConfig.trackRecommendationAcceptanceCommand = 'mockTrackRecommendationAcceptanceCommand';
+
+        const title = 'rhtpa (hardened): Switch to ubi9/openjdk-11-hardened for enhanced security';
+        const codeAction: CodeAction = codeActionHandler.generateRedirectToRecommendedVersionAction(
+            title,
+            'ubi9/openjdk-11-hardened',
+            mockDiagnostic1[0],
+            Uri.file('mock/path/Dockerfile')
+        );
+
+        expect(codeAction).to.deep.equal(
+            {
+                'command': {
+                    'command': 'mockTrackRecommendationAcceptanceCommand',
+                    'title': 'Track recommendation acceptance',
+                    'arguments': [
+                        'ubi9/openjdk-11-hardened',
+                        'Dockerfile'
+                    ]
+                },
+                'diagnostics': [
+                    {
+                        'message': 'another mock message',
+                        'range': new Range(321, 321, 654, 654),
+                        'severity': 3,
+                        'source': 'mockSource'
+                    }
+                ],
+                'kind': { 'value': 'quickfix' },
+                'title': title
+            }
+        );
+    });
+
+    /**
      * Verifies that code action uses the correct recommendation ref per source type
      * when recommendationSourceId is set on the DependencyData.
      */

--- a/test/codeActionHandler.test.ts
+++ b/test/codeActionHandler.test.ts
@@ -420,17 +420,28 @@ suite('Code Action Handler tests', () => {
     });
 
     /**
-     * Verifies that code action for hardened image recommendation uses distinct title.
+     * Verifies that code action for hardened image recommendation uses de-branded title.
      */
-    test('should generate redirect code action for hardened image recommendation', async () => {
+    test('should generate replace image code action for hardened image recommendation with generic title', async () => {
         config.globalConfig.trackRecommendationAcceptanceCommand = 'mockTrackRecommendationAcceptanceCommand';
-
+        const uri = Uri.file('mock/path/Dockerfile');
         const title = 'rhtpa (hardened): Switch to ubi9/openjdk-11-hardened for enhanced security';
-        const codeAction: CodeAction = codeActionHandler.generateRedirectToRecommendedVersionAction(
+        const imageName: IPositionedString = { value: 'golang:1.21', position: { line: 322, column: 5 } };
+
+        const expectedRange = new Range(
+            new Position(321, 5),
+            new Position(321, 5 + 'golang:1.21'.length)
+        );
+        const edit = new WorkspaceEdit();
+        edit.replace(uri, expectedRange, 'ubi9/openjdk-11-hardened');
+        const codeAction: CodeAction = codeActionHandler.generateReplaceImageAction(
             title,
             'ubi9/openjdk-11-hardened',
+            'ubi9/openjdk-11-hardened',
+            undefined,
             mockDiagnostic1[0],
-            Uri.file('mock/path/Dockerfile')
+            uri,
+            imageName
         );
 
         expect(codeAction).to.deep.equal(
@@ -440,17 +451,19 @@ suite('Code Action Handler tests', () => {
                     'title': 'Track recommendation acceptance',
                     'arguments': [
                         'ubi9/openjdk-11-hardened',
+                        undefined,
                         'Dockerfile'
                     ]
                 },
                 'diagnostics': [
                     {
                         'message': 'another mock message',
-                        'range': new Range(321, 321, 654, 654),
+                        'range': mockDiagnostic1[0].range,
                         'severity': 3,
                         'source': 'mockSource'
                     }
                 ],
+                'edit': edit,
                 'kind': { 'value': 'quickfix' },
                 'title': title
             }

--- a/test/vulnerability.test.ts
+++ b/test/vulnerability.test.ts
@@ -482,23 +482,6 @@ suite('Vulnerability tests', () => {
      * Verifies that image recommendations read from provider level
      * display the correct source label in the diagnostic message.
      */
-    test('should return diagnostic with provider-level recommendation for image data', async () => {
-        config.globalConfig.recommendationsEnabled = true;
-
-        const mockImageData: MockImageData[] = [
-            new MockImageData('rhtpa', [], 'ubi8/openjdk-11', 'NONE', 'hardened-images')
-        ];
-        const vulnerability = new Vulnerability(
-            mockRange,
-            mockImageRef,
-            mockImageData
-        );
-
-        const diagnostic = vulnerability.getDiagnostic();
-        expect(diagnostic.message).to.include('rhtpa hardened-images recommendation:');
-        expect(diagnostic.message).to.include('ubi8/openjdk-11');
-        expect(diagnostic.severity).to.eql(DiagnosticSeverity.Information);
-    });
 
     /**
      * Verifies that trusted registry instructions appear only for
@@ -539,9 +522,8 @@ suite('Vulnerability tests', () => {
         );
 
         const diagnostic = vulnerability.getDiagnostic();
-        expect(diagnostic.message).to.include('rhtpa recommendation:');
-        expect(diagnostic.message).to.include('Recommended image: ubi9/openjdk-11-hardened');
-        expect(diagnostic.message).to.not.include('hardened recommendation:');
+        expect(diagnostic.message).to.include('rhtpa hardened recommendation:');
+        expect(diagnostic.message).to.include('Recommended: ubi9/openjdk-11-hardened');
         expect(diagnostic.severity).to.eql(DiagnosticSeverity.Information);
     });
 
@@ -562,7 +544,7 @@ suite('Vulnerability tests', () => {
         );
 
         const diagnostic = vulnerability.getDiagnostic();
-        expect(diagnostic.message).to.not.include('Recommended image:');
+        expect(diagnostic.message).to.not.include('Recommended:');
     });
 
     /**

--- a/test/vulnerability.test.ts
+++ b/test/vulnerability.test.ts
@@ -170,7 +170,7 @@ suite('Vulnerability tests', () => {
 
             tpa(tpa) vulnerability info:
             Known security vulnerabilities: 0
-            Recommendation: No Red Hat recommendations
+            Recommendation: No recommendations
         `.replace(/\s/g, ''));
     });
 
@@ -192,7 +192,7 @@ suite('Vulnerability tests', () => {
 
             tpa(tpa) vulnerability info:
             Known security vulnerabilities: 0
-            Recommendation: No Red Hat recommendations
+            Recommendation: No recommendations
 
             oss(oss) vulnerability info:
             Known security vulnerabilities: 0
@@ -524,7 +524,7 @@ suite('Vulnerability tests', () => {
 
     /**
      * Verifies that hardened image recommendations produce a distinct diagnostic
-     * message with "A Red Hat Hardened Image is available" text.
+     * message with "Recommended image" text.
      */
     test('should return diagnostic with hardened image recommendation message', async () => {
         config.globalConfig.recommendationsEnabled = true;
@@ -540,7 +540,7 @@ suite('Vulnerability tests', () => {
 
         const diagnostic = vulnerability.getDiagnostic();
         expect(diagnostic.message).to.include('rhtpa recommendation:');
-        expect(diagnostic.message).to.include('A Red Hat Hardened Image is available: ubi9/openjdk-11-hardened');
+        expect(diagnostic.message).to.include('Recommended image: ubi9/openjdk-11-hardened');
         expect(diagnostic.message).to.not.include('hardened recommendation:');
         expect(diagnostic.severity).to.eql(DiagnosticSeverity.Information);
     });
@@ -562,7 +562,7 @@ suite('Vulnerability tests', () => {
         );
 
         const diagnostic = vulnerability.getDiagnostic();
-        expect(diagnostic.message).to.not.include('A Red Hat Hardened Image is available');
+        expect(diagnostic.message).to.not.include('Recommended image:');
     });
 
     /**


### PR DESCRIPTION
## Summary

- Remove "Red Hat UBI" and "Red Hat Hardened" branding from image and dependency recommendation Quick Fix titles
- Replace "A Red Hat Hardened Image is available" with "Recommended image" in diagnostic hover messages
- Remove dead `hardened` special-case branch from dependency Quick Fix code action
- Remove outdated Ecosystem Catalog reference from README Docker scanning section
- Update "No Red Hat recommendations" to "No recommendations" in fallback message

## Test plan

- [x] `npm test` — 303 passing (1 pre-existing unrelated failure in fileHandler)
- [x] No remaining "Red Hat UBI" or "Red Hat Hardened" branding in recommendation workflow

Implements [TC-4973](https://redhat.atlassian.net/browse/TC-4973)

[TC-4973]: https://redhat.atlassian.net/browse/TC-4973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Remove vendor-specific Red Hat UBI/hardened branding from recommendation messaging while keeping recommendation functionality intact.

Enhancements:
- Standardize image and dependency recommendation titles and hover messages to use neutral wording like "Recommended image" and generic version switch phrasing.
- Simplify recommendation code paths by removing the special-case hardened branch in dependency quick-fix generation.
- Adjust vulnerability diagnostics fallback text to use generic "No recommendations" copy instead of vendor-specific wording.

Documentation:
- Remove outdated reference to Red Hat's Ecosystem Catalog from the Docker scanning README section.

Tests:
- Update vulnerability and code action tests to reflect the new neutral recommendation messages and titles.