### PR TITLE
chore: bump CI node to 24 LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://npm.pkg.github.com'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         run: npm run test-compile
 
       - name: VSCE prepublish
-        run: vsce package
+        run: vsce package --no-dependencies
 
       - name: Lint code
         run: npm run lint

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -57,7 +57,7 @@ jobs:
         run: npm run test-compile
 
       - name: VSCE package
-        run: vsce package --out fabric8-analytics-${{ steps.bump.outputs.version }}-${{ github.run_number }}.vsix
+        run: vsce package --out fabric8-analytics-${{ steps.bump.outputs.version }}-${{ github.run_number }}.vsix --no-dependencies
 
       - name: Create SHA256 checksum
         run: |

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://npm.pkg.github.com'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://npm.pkg.github.com'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "version=v$new_version" >> "$GITHUB_OUTPUT"
 
       - name: VSCE package
-        run: vsce package --out fabric8-analytics-${{ steps.release_version.outputs.version }}-${{ github.run_number }}.vsix
+        run: vsce package --out fabric8-analytics-${{ steps.release_version.outputs.version }}-${{ github.run_number }}.vsix --no-dependencies
 
       - name: Create SHA256 checksum
         run: |

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://npm.pkg.github.com'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: VSCE package
         run: |
-          vsce package --out fabric8-analytics-${{ steps.ea_version.outputs.version }}.vsix
+          vsce package --out fabric8-analytics-${{ steps.ea_version.outputs.version }}.vsix --no-dependencies
 
       - name: Create SHA256 checksum
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -994,43 +994,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@trustify-da/trustify-da-javascript-client/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@trustify-da/trustify-da-javascript-client/node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@trustify-da/trustify-da-javascript-client/node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -1115,14 +1078,6 @@
       "engines": {
         "node": ">= 20"
       }
-    },
-    "node_modules/@trustify-da/trustify-da-javascript-client/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@trustify-da/trustify-da-javascript-client/node_modules/node-fetch": {
       "version": "3.3.2",
@@ -7238,6 +7193,8 @@
     },
     "node_modules/tree-sitter-python": {
       "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.23.6.tgz",
+      "integrity": "sha512-yIM9z0oxKIxT7bAtPOhgoVl6gTXlmlIhue7liFT4oBPF/lha7Ha4dQBS82Av6hMMRZoVnFJI8M6mL+SwWoLD3A==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,18 @@
   "engines": {
     "vscode": "^1.76.0"
   },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "onFail": "warn",
+      "version": ">=24.0.0"
+    },
+    "packageManager": {
+      "name": "npm",
+      "onFail": "warn",
+      "version": ">=11.5.1"
+    }
+  },
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
@@ -612,5 +624,12 @@
   },
   "overrides": {
     "lodash": "4.18.1"
+  },
+  "allowScripts": {
+    "unrs-resolver@1.11.1": true,
+    "tree-sitter@0.22.4": true,
+    "github:strum355/tree-sitter-go-mod#56326f2ad478892ace58ff247a97d492a3cbcdda": true,
+    "github:Strum355/tree-sitter-requirements#d0261ee76b84253997fe70d7d397e78c006c3801": true,
+    "tree-sitter-python@0.23.6": true
   }
 }


### PR DESCRIPTION
Brings the version in-line with trustify-da-js-client, which may have been the reason for the CI failure in https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/928

Adds warn-only checks for npm & node version in `package.json` via `devEngines`.

Adds `--no-dependencies` flag to `vsce package` calls. This flag "disable(s) dependency detection via npm or yarn", which can cause issues when theres some whackiness in the dependency tree (peer dependency version conflicts etc) which is irrelevant to us for this purpose because we use webpack for bundling. This flag was specifically created for this purpose https://github.com/microsoft/vscode-vsce/issues/439

## Summary by Sourcery

Align project automation with the Node.js 24 LTS toolchain and make extension packaging compatible with the updated environment.

Enhancements:
- Upgrade CI, staging, preparation, and release workflows to use Node.js 24.
- Add warn-only development environment checks for Node.js and npm versions.
- Package VS Code extensions without bundling dependencies in automated workflows.

Build:
- Update package metadata and lockfile for the Node.js 24 and npm 11 development environment, including approved dependency install scripts.